### PR TITLE
Basic shell script to create sub-theme

### DIFF
--- a/scripts/create_subtheme.sh
+++ b/scripts/create_subtheme.sh
@@ -1,0 +1,190 @@
+#!/bin/bash
+# Script to quickly create sub-theme.
+
+echo '
++--------------------------------------------------------------------------------------+
+| This scripts creates the basic foundations of a LocalGov Base sub-theme:             |
+|                                                                                      |
+|  - theme/custom/your_sub_theme/                                                      |
+|  - theme/custom/your_sub_theme/logo.svg                                              |
+|  - theme/custom/your_sub_theme/your_sub_theme.info.yml                               |
+|  - theme/custom/your_sub_theme/your_sub_theme.libraries.yml                          |
+|  - theme/custom/your_sub_theme/config/                                               |
+|  - theme/custom/your_sub_theme/config/install/                                       |
+|  - theme/custom/your_sub_theme/config/install/your_sub_theme.settings.yml            |
+|  - theme/custom/your_sub_theme/css/                                                  |
+|  - theme/custom/your_sub_theme/css/variables.css                                     |
+|                                                                                      |
++--------------------------------------------------------------------------------------+
+'
+
+# Check we're in the right place
+foldername="$(basename $PWD)"
+parentfoldername="$(basename "$(dirname $PWD)")"
+
+if [ "${foldername}" != "localgov_base" ]; then
+  echo 'Error: This command should be run from the LocalGov Base Theme root folder (themes/contrib/localgov_base).'
+  exit
+fi
+
+if [ "${parentfoldername}" != "contrib" ]; then
+  echo 'Error: The localgov_base theme (this folder) should be in the "contrib" folder.'
+  exit
+fi
+
+# Get theme name
+echo 'Please enter the full name for your theme [e.g. Scarfolk Council Theme]'
+read -p '> ' LGD_SUB_THEME_NAME
+if [ -z "${LGD_SUB_THEME_NAME}" ]; then
+  echo 'Error: Please enter a name [e.g. Scarfolk Council Theme]'
+  exit
+fi
+
+# Get theme machine name
+echo 'Please enter the machine name for your theme [e.g. scarfolk_council]'
+read -p '> ' LGD_SUB_THEME
+if [ -z "${LGD_SUB_THEME}" ]; then
+  echo 'Error: Please enter a machine name [e.g. scarfolk_council]'
+  exit
+fi
+
+# Create theme folder
+if [[ ! -e ../../custom ]]; then
+  mkdir ../../custom
+  echo '+ themes/custom/ folder created'
+fi
+
+cd ../../custom
+
+if [[ -e $LGD_SUB_THEME ]]; then
+  echo "+ themes/custom/$LGD_SUB_THEME folder already exists, exiting"
+  exit
+fi
+
+mkdir $LGD_SUB_THEME
+echo "+ themes/custom/$LGD_SUB_THEME folder created"
+
+cd $LGD_SUB_THEME
+
+cp ../../contrib/localgov_base/logo.svg .
+echo "+ themes/custom/$LGD_SUB_THEME/logo.svg copied"
+
+# theme.info.yml
+cat > $LGD_SUB_THEME.info.yml << EOF
+name: "$LGD_SUB_THEME_NAME"
+description: "A sub-theme of localgov_base."
+type: theme
+core_version_requirement: ^8.8 || ^9
+base theme: "localgov_base"
+
+libraries:
+  - $LGD_SUB_THEME/variables
+
+regions:
+  tabs: "Tabs"
+  header: "Header"
+  search: "Search"
+  mobile_search: "Mobile search"
+  primary_menu: "Primary menu"
+  secondary_menu: "Secondary menu"
+  banner: "Banner"
+  breadcrumb: "Breadcrumb"
+  messages: "Messages"
+  content_top: "Content top"
+  content: "Content"
+  content_bottom: "Content bottom"
+  sidebar_first: "Sidebar first"
+  sidebar_second: "Sidebar second"
+  footer_first: "Footer first"
+  footer_second: "Footer second"
+  footer_third: "Footer third"
+  footer: "Footer"
+  lower_footer_first: "Lower footer first"
+  lower_footer_second: "Lower footer second"
+  lower_footer_third: "Lower footer third"
+  disabled: "Disabled"
+
+EOF
+
+echo "+ themes/custom/$LGD_SUB_THEME/$LGD_SUB_THEME.info.yml created"
+
+# theme.libraries.yml
+cat > $LGD_SUB_THEME.libraries.yml << EOF
+variables:
+  css:
+    theme:
+      css/variables.css: {}
+EOF
+
+echo "+ themes/custom/$LGD_SUB_THEME/$LGD_SUB_THEME.libraries.yml created"
+
+mkdir config
+mkdir config/install
+echo "+ themes/custom/$LGD_SUB_THEME/config/install/ created"
+
+# theme.settings.yml
+cat > config/install/$LGD_SUB_THEME.settings.yml << EOF
+localgov_base_use_css: true
+localgov_base_use_js: true
+EOF
+
+echo "+ themes/custom/$LGD_SUB_THEME/config/install/$LGD_SUB_THEME.settings.yml created"
+
+if [[ ! -e css ]]; then
+  mkdir css
+  echo "+ themes/custom/$LGD_SUB_THEME/css/ created"
+fi
+
+# variables.css
+cat > css/variables.css << EOF
+/*
+  Import fonts.
+
+  In the base theme, we have no fonts importing so that the theme is as fast
+  as possible, and so we are not loading fonts that are then going to be
+  overridden in a sub-theme in any case.
+
+  Want a font? Load it here, or in the html.html.twig file (you'll have to
+  copy that file to the theme) which might give you an even faster loading time.
+
+  For example:
+
+  @import url('https://fonts.googleapis.com/css2?family=Lato:wght@300;400;700&display=swap');
+*/
+
+/*
+  Override variables for your sub-theme. The full list of variables can be
+  found in the localgov_base theme variables.css file.
+
+  In the base theme, most item values are set as variables. These variables
+  usually reference other variables. For example, we have a certain number of
+  colours, font sizes, spacing units, etc. We then create specific variables
+  (for example a variable for the color of a link in the header) but these
+  specific variables reference our base "root" variables.
+
+  The overrides here give an example of what you might want to change. As you
+  can see, you can change as much or as little as you wish.
+
+  Examples:
+  - The base font size in the base theme is 16px (1rem). If you want
+    all your fonts to be based on a different scale, set --font-size variable
+    to something else.
+  - The base line-height is 1.5 in the base theme. If you want that to be 1.3,
+    set --line-height to 1.3. A lot of spacing between items is based on this
+    rhythm (1.5rem), so changing to 1.3 will update all across the board.
+  - The accent colour in our base theme is purple. If you would like it to be
+    hotpink, just set --color-accent: hotpink;
+*/
+:root {
+  --color-accent: #993913;
+  --font-primary: -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",sans-serif;
+  --font-secondary: Constantia, "Lucida Bright", Lucidabright, "Lucida Serif", Lucida, "DejaVu Serif", "Bitstream Vera Serif", "Liberation Serif", Georgia, serif;
+}
+EOF
+
+echo "+ themes/custom/$LGD_SUB_THEME/css/variables.css created"
+
+echo ""
+echo "# Your new localgov_base sub-theme has been created."
+echo "# Check the themes/custom folder to access the theme files."
+echo "# Install your sub-theme using drush or from the Drupal Appearance menu"

--- a/scripts/create_subtheme.sh
+++ b/scripts/create_subtheme.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Script to quickly create sub-theme.
+# Script to easily create a localgov_base sub-theme.
 
 echo '
 +--------------------------------------------------------------------------------------+
@@ -18,7 +18,7 @@ echo '
 +--------------------------------------------------------------------------------------+
 '
 
-# Check we're in the right place
+# Check we're in the right place.
 foldername="$(basename $PWD)"
 parentfoldername="$(basename "$(dirname $PWD)")"
 
@@ -32,7 +32,7 @@ if [ "${parentfoldername}" != "contrib" ]; then
   exit
 fi
 
-# Get theme name
+# Get theme name.
 echo 'Please enter the full name for your theme [e.g. Scarfolk Council Theme]'
 read -p '> ' LGD_SUB_THEME_NAME
 if [ -z "${LGD_SUB_THEME_NAME}" ]; then
@@ -40,7 +40,7 @@ if [ -z "${LGD_SUB_THEME_NAME}" ]; then
   exit
 fi
 
-# Get theme machine name
+# Get theme machine name.
 echo 'Please enter the machine name for your theme [e.g. scarfolk_council]'
 read -p '> ' LGD_SUB_THEME
 if [ -z "${LGD_SUB_THEME}" ]; then
@@ -48,7 +48,7 @@ if [ -z "${LGD_SUB_THEME}" ]; then
   exit
 fi
 
-# Create theme folder
+# Create theme folder.
 if [[ ! -e ../../custom ]]; then
   mkdir ../../custom
   echo '+ themes/custom/ folder created'
@@ -69,7 +69,7 @@ cd $LGD_SUB_THEME
 cp ../../contrib/localgov_base/logo.svg .
 echo "+ themes/custom/$LGD_SUB_THEME/logo.svg copied"
 
-# theme.info.yml
+# theme.info.yml.
 cat > $LGD_SUB_THEME.info.yml << EOF
 name: "$LGD_SUB_THEME_NAME"
 description: "A sub-theme of localgov_base."
@@ -108,7 +108,7 @@ EOF
 
 echo "+ themes/custom/$LGD_SUB_THEME/$LGD_SUB_THEME.info.yml created"
 
-# theme.libraries.yml
+# theme.libraries.yml.
 cat > $LGD_SUB_THEME.libraries.yml << EOF
 variables:
   css:
@@ -122,7 +122,7 @@ mkdir config
 mkdir config/install
 echo "+ themes/custom/$LGD_SUB_THEME/config/install/ created"
 
-# theme.settings.yml
+# theme.settings.yml.
 cat > config/install/$LGD_SUB_THEME.settings.yml << EOF
 localgov_base_use_css: true
 localgov_base_use_js: true
@@ -135,7 +135,7 @@ if [[ ! -e css ]]; then
   echo "+ themes/custom/$LGD_SUB_THEME/css/ created"
 fi
 
-# variables.css
+# variables.css.
 cat > css/variables.css << EOF
 /*
   Import fonts.


### PR DESCRIPTION
This PR closes #61 and adds a workmanlike shell script that:

- Checks the script is being run in the correct folder, and that localgov_base is in the themes/contrib folder.
- Prompts the user for a theme name, and a theme machine name
- Creates the themes/custom folder if it doesn't exist
- Checks if a themes/custom/sub_theme folder exists, and exits if it does
- Creates the themes/custom/sub_theme folder
- Copies logo.svg from the localgov_base theme
- Creates theme_name.info.yml with this content (with variables replaced):

```
name: "$LGD_SUB_THEME_NAME"
description: "A sub-theme of localgov_base."
type: theme
core_version_requirement: ^8.8 || ^9
base theme: "localgov_base"

libraries:
  - $LGD_SUB_THEME/variables

regions:
  tabs: "Tabs"
  header: "Header"
  search: "Search"
  mobile_search: "Mobile search"
  primary_menu: "Primary menu"
  secondary_menu: "Secondary menu"
  banner: "Banner"
  breadcrumb: "Breadcrumb"
  messages: "Messages"
  content_top: "Content top"
  content: "Content"
  content_bottom: "Content bottom"
  sidebar_first: "Sidebar first"
  sidebar_second: "Sidebar second"
  footer_first: "Footer first"
  footer_second: "Footer second"
  footer_third: "Footer third"
  footer: "Footer"
  lower_footer_first: "Lower footer first"
  lower_footer_second: "Lower footer second"
  lower_footer_third: "Lower footer third"
  disabled: "Disabled"
```

- Creates theme_name.libraries.yml with this default content:

```
variables:
  css:
    theme:
      css/variables.css: {}
```

- Creates themes/custom/theme_name/config/install/ folder(s)
- Creates theme_name.settings.yml with this content:

```
localgov_base_use_css: true
localgov_base_use_js: true
```

- Creates themes/custom/theme_name/css/ folder
- Creates themes/custom/theme_name/css/variables.css with this content:

```
/*
  Import fonts.

  In the base theme, we have no fonts importing so that the theme is as fast
  as possible, and so we are not loading fonts that are then going to be
  overridden in a sub-theme in any case.

  Want a font? Load it here, or in the html.html.twig file (you'll have to
  copy that file to the theme) which might give you an even faster loading time.

  For example:

  @import url('https://fonts.googleapis.com/css2?family=Lato:wght@300;400;700&display=swap');
*/

/*
  Override variables for your sub-theme. The full list of variables can be
  found in the localgov_base theme variables.css file.

  In the base theme, most item values are set as variables. These variables
  usually reference other variables. For example, we have a certain number of
  colours, font sizes, spacing units, etc. We then create specific variables
  (for example a variable for the color of a link in the header) but these
  specific variables reference our base "root" variables.

  The overrides here give an example of what you might want to change. As you
  can see, you can change as much or as little as you wish.

  Examples:
  - The base font size in the base theme is 16px (1rem). If you want
    all your fonts to be based on a different scale, set --font-size variable
    to something else.
  - The base line-height is 1.5 in the base theme. If you want that to be 1.3,
    set --line-height to 1.3. A lot of spacing between items is based on this
    rhythm (1.5rem), so changing to 1.3 will update all across the board.
  - The accent colour in our base theme is purple. If you would like it to be
    hotpink, just set --color-accent: hotpink;
*/
:root {
  --color-accent: #993913;
  --font-primary: -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",sans-serif;
  --font-secondary: Constantia, "Lucida Bright", Lucidabright, "Lucida Serif", Lucida, "DejaVu Serif", "Bitstream Vera Serif", "Liberation Serif", Georgia, serif;
}
```

After successful theme creation the user is directed to the location of the new theme files, and how to install the theme.

This results in a sub-theme that looks something like this, with a neutral rust accent colour and system font stacks:

<img width="1264" alt="Screenshot 2021-06-23 at 16 17 25" src="https://user-images.githubusercontent.com/261421/123123332-a9659600-d43e-11eb-8986-ae747fe69f74.png">

### Potential improvements:

- Create a theme starterkit so the relevant files can be copied rather than having all the content in a single shell script.
