### PR TITLE
adds 50% width to grid items when on tablet screen sizes

### DIFF
--- a/css/layout/grid.css
+++ b/css/layout/grid.css
@@ -17,18 +17,42 @@
   - .lgd-row--thirds - direct descendants are all 33% each
   - .lgd-row--quarters - direct descendants are all 25% each
 */
+.lgd-row {
+  display: flex;
+  flex-wrap: wrap;
+}
+
+.lgd-row > * {
+  margin-right: calc(var(--spacing) / 2);
+  margin-left: calc(var(--spacing) / 2);
+}
+
+.lgd-row__one-quarter,
+.lgd-row--quarters > *,
+.lgd-row__one-third,
+.lgd-row--thirds > *,
+.lgd-row__one-half,
+.lgd-row--halves > *,
+.lgd-row__two-thirds,
+.lgd-row__three-quarters,
+.lgd-row__full {
+  width: calc(100% - var(--spacing));
+}
 
 @media screen and (min-width: 48rem) {
-  .lgd-row {
-    display: flex;
-    flex-wrap: wrap;
+  .lgd-row__one-quarter,
+  .lgd-row--quarters > *,
+  .lgd-row__one-third,
+  .lgd-row--thirds > *,
+  .lgd-row__one-half,
+  .lgd-row--halves > *,
+  .lgd-row__two-thirds,
+  .lgd-row__three-quarters {
+    width: calc(50% - var(--spacing));
   }
+}
 
-  .lgd-row > * {
-    margin-right: calc(var(--spacing) / 2);
-    margin-left: calc(var(--spacing) / 2);
-  }
-
+@media screen and (min-width: 60rem) {
   .lgd-row__one-quarter,
   .lgd-row--quarters > * {
     width: calc(25% - var(--spacing));
@@ -39,20 +63,11 @@
     width: calc(33% - var(--spacing));
   }
 
-  .lgd-row__one-half,
-  .lgd-row--halves > * {
-    width: calc(50% - var(--spacing));
-  }
-
   .lgd-row__two-thirds {
     width: calc((100% / 3 * 2) - var(--spacing));
   }
 
   .lgd-row__three-quarters {
     width: calc(75% - var(--spacing));
-  }
-
-  .lgd-row__full {
-    width: calc(100% - var(--spacing));
   }
 }

--- a/css/layout/grid.ie11.css
+++ b/css/layout/grid.ie11.css
@@ -1,10 +1,35 @@
 /* IE11 Fallbacks */
-@media screen and (min-width: 48rem) {
 
-  .lgd-row > * {
-    margin-right: 0.5rem;
-    margin-left: 0.5rem;
+.lgd-row > * {
+  margin-right: 0.5rem;
+  margin-left: 0.5rem;
+}
+
+.lgd-row__one-quarter,
+.lgd-row--quarters > *,
+.lgd-row__one-third,
+.lgd-row--thirds > *,
+.lgd-row__one-half,
+.lgd-row--halves > *,
+.lgd-row__two-thirds,
+.lgd-row__three-quarters,
+.lgd-row__full {
+  width: calc(100% - 1rem);
+}
+
+@media screen and (min-width: 48rem) {
+  .lgd-row__one-quarter,
+  .lgd-row--quarters > *,
+  .lgd-row__one-third,
+  .lgd-row--thirds > *,
+  .lgd-row__one-half,
+  .lgd-row--halves > *,
+  .lgd-row__two-thirds,
+  .lgd-row__three-quarters {
+    width: calc(50% - 1rem);
   }
+}
+@media screen and (min-width: 60rem) {
 
   .lgd-row__one-quarter,
   .lgd-row--quarters > * {
@@ -16,20 +41,11 @@
     width: calc(33% - 1rem);
   }
 
-  .lgd-row__one-half,
-  .lgd-row--halves > * {
-    width: calc(50% - 1rem);
-  }
-
   .lgd-row__two-thirds {
     width: calc((100% / 3 * 2) - 1rem);
   }
 
   .lgd-row__three-quarters {
     width: calc(75% - 1rem);
-  }
-
-  .lgd-row__full {
-    width: calc(100% - 1rem);
   }
 }


### PR DESCRIPTION
This PR sets grid items to 
 - 100% width when on small screens 
 - 50% width when on medium sized screens, 
 - Correct fraction (quarter, half, etc) when on large screens.

Mobile
![mobile](https://user-images.githubusercontent.com/2183332/131530545-8b85dfe6-62b7-475e-a592-88ec57089da5.jpg)


Tablet
![tablet](https://user-images.githubusercontent.com/2183332/131530576-c4698a95-8951-4a43-9dc1-7ec865521781.jpg)


Desktop
![desktop](https://user-images.githubusercontent.com/2183332/131530575-e7157415-f91f-4b20-8c7b-6d4c09897ec8.jpg)
