### PR TITLE
Allow outline in maps to be set via CSS variable

### DIFF
--- a/css/base/variables.css
+++ b/css/base/variables.css
@@ -381,4 +381,7 @@ body {
   --alert-banner-inner-margin-horizontal: 0;
   --alert-banner-inner-padding-vertical: var(--spacing);
   --alert-banner-inner-padding-horizontal: 0;
+
+  /* Leaflet Mapping */
+  --leaflet-map-outline-stroke: #3388ff;
 }

--- a/css/base/variables.css
+++ b/css/base/variables.css
@@ -383,5 +383,5 @@ body {
   --alert-banner-inner-padding-horizontal: 0;
 
   /* Leaflet Mapping */
-  --leaflet-map-outline-stroke: #3388ff;
+  --leaflet-map-outline-stroke-colour: #3388ff;
 }

--- a/css/components/leaflet.css
+++ b/css/components/leaflet.css
@@ -1,3 +1,3 @@
 .leaflet-interactive {
-  stroke: var(--leaflet-map-outline-stroke);
+  stroke: var(--leaflet-map-outline-stroke-colour);
 }

--- a/css/components/leaflet.css
+++ b/css/components/leaflet.css
@@ -1,0 +1,3 @@
+.leaflet-interactive {
+  stroke: var(--leaflet-map-outline-stroke);
+}

--- a/css/components/leaflet.ie11.css
+++ b/css/components/leaflet.ie11.css
@@ -1,0 +1,3 @@
+.leaflet-interactive {
+  stroke: #3388ff;
+}

--- a/localgov_base.libraries.yml
+++ b/localgov_base.libraries.yml
@@ -265,3 +265,9 @@ sitewide-search:
     theme:
       css/components/sitewide-search.ie11.css: {}
       css/components/sitewide-search.css: {}
+
+leaflet:
+  css:
+    theme:
+      css/components/leaflet.ie11.css: {}
+      css/components/leaflet.css: {}

--- a/templates/misc/leaflet-map.html.twig
+++ b/templates/misc/leaflet-map.html.twig
@@ -1,0 +1,23 @@
+{#
+/**
+ * @file
+ * Theme implementation to display a Leaflet map.
+ *
+ * This creates a placeholder for the map to be injected in.
+ *
+ * Available variables:
+ * - map_id
+ * - height
+ *
+ * Note: min-width is set so that a map will show when "Inline" is specified
+ * for the associated field label. This may of course be overridden. The default
+ * field label style is "Above" with a width of 100%.
+ *
+ * @ingroup themeable
+ *
+ */
+#}
+
+{{ attach_library('localgov_base/leaflet') }}
+
+<div id="{{ map_id }}" style="min-width: 150px; {% if height is not empty %}height: {{ height }}{% endif %}"></div>


### PR DESCRIPTION
This PR fixes #160 

We now have a variable set in the base theme to allow us to override the default blue outline we have for maps. 

The variable is called `--leaflet-map-outline-stroke-colour`. It's currently set to the same colour blue as the default map, so current sites will not see any difference unless they set this variable in the variables.css file.