### PR TITLE
fixes theme name not getting rewritten on mac after subtheme script

### DIFF
--- a/scripts/create_subtheme.sh
+++ b/scripts/create_subtheme.sh
@@ -69,8 +69,8 @@ echo "+ themes/custom/$LGD_SUB_THEME/package.json created"
 cp ../../contrib/localgov_base/scripts/subtheme-items/.nvmrc .nvmrc
 echo "+ themes/custom/$LGD_SUB_THEME/.nvmrc created"
 
-sed -i "s/LGD_SUB_THEME_NAME/$LGD_SUB_THEME_NAME/g" *
-sed -i "s/LGD_SUB_THEME/$LGD_SUB_THEME/g" *
+perl -i -pe "s/LGD_SUB_THEME_NAME/$LGD_SUB_THEME_NAME/g" *
+perl -i -pe "s/LGD_SUB_THEME/$LGD_SUB_THEME/g" *
 echo "+ variables replaced"
 
 cp -r ../../contrib/localgov_base/scripts/subtheme-items/css .


### PR DESCRIPTION
This seems to fix the issue, using `perl` instead of `sed` for issue #171 