### PR TITLE
Don't error when no search form present in header

### DIFF
--- a/js/header.js
+++ b/js/header.js
@@ -14,7 +14,9 @@ if (window.NodeList && !NodeList.prototype.forEach) {
       context = context || document;
 
       const headerSearchForm = context.querySelector('.lgd-region--search form');
-      headerSearchForm.querySelector('label').classList.add('visually-hidden');
+      if (headerSearchForm) {
+        headerSearchForm.querySelector('label').classList.add('visually-hidden');
+      }
 
       let windowWidth = window.innerWidth;
 


### PR DESCRIPTION
Some pages on a council site we're building don't have a search box in the header.

Since recently on these pages, we've been hitting a javascript error in the header.js file, breaking e.g. the expanding menu on mobile.