### PR TITLE
adds container by default to layouts that choose no width settings

### DIFF
--- a/templates/paragraphs/paragraph--localgov-page-section.html.twig
+++ b/templates/paragraphs/paragraph--localgov-page-section.html.twig
@@ -45,7 +45,7 @@
 {%
   set classes = [
     'lgd-page-section',
-    width ? 'lgd-page-section--' ~ width,
+    width ? 'lgd-page-section--' ~ width : 'lgd-container padding-horizontal',
     width == 'full-width' ? 'padding-horizontal',
     width == 'contained-content' ? 'padding-horizontal',
     width == 'contained-content' ? 'lgd-container',


### PR DESCRIPTION
This is a simple PR, just to add a container class to layout paragraphs if no specific width is chosen. It's just a sensible default that means layouts will behave as they currently do, and our new width field is an addition to it.