### PR TITLE
stops columns in guide nav overspilling to next column

### DIFF
--- a/css/components/guide-nav.css
+++ b/css/components/guide-nav.css
@@ -17,6 +17,7 @@
 .lgd-guide-nav__list-item {
   margin-bottom: var(--spacing);
   font-size: var(--font-size-large);
+  break-inside: avoid-column;
 }
 
 .lgd-guide-nav__list-item > a {


### PR DESCRIPTION
Closes #261

Before:

![Screenshot 2022-08-03 at 14 49 07](https://user-images.githubusercontent.com/2183332/182625899-c7fc80c5-c02f-4352-9b9b-4cf84895418f.jpg)

After:
![Screenshot 2022-08-03 at 14 54 12](https://user-images.githubusercontent.com/2183332/182625924-3500f9b4-668f-432d-9042-e546323d0338.jpg)

