### PR TITLE
adds sitewide search theming

### DIFF
--- a/css/base/variables.css
+++ b/css/base/variables.css
@@ -388,6 +388,8 @@ body {
   --news-category-spacing: var(--spacing);
 
   /* Search Results */
+  --sitewide-search-header-container-padding-horizontal: var(--spacing);
+  --sitewide-search-header-container-padding-vertical: var(--spacing);
   --search-results-item-spacing: var(--spacing-largest);
   --search-results-list-item-border: var(--border);
   --search-results-list-item-marker-color: transparent;

--- a/css/components/sitewide-search.css
+++ b/css/components/sitewide-search.css
@@ -1,3 +1,22 @@
+.lgd-search-results-list__header-container {
+  padding: var(--sitewide-search-header-container-padding-vertical) var(--sitewide-search-header-container-padding-horizontal);
+  border: var(--border);
+  border-radius: var(--border-radius);
+}
+
+.lgd-search-results-list .view-header {
+  margin-bottom: var(--vertical-rhythm-spacing);
+}
+
+.lgd-search-results-list .views-exposed-form {
+  display: flex;
+  align-items: end;
+}
+
+.lgd-search-results-list .form-item {
+  margin-bottom: 0;
+}
+
 .lgd-search-results-list > * {
   margin-bottom: var(--search-results-item-spacing);
 }
@@ -7,17 +26,17 @@
   flex-wrap: wrap;
 }
 
-.lgd-search-results-list .search-results {
+.lgd-search-results-list .item-list > * {
   padding-left: 0;
 }
 
-.lgd-search-results-list .search-results > li {
+.lgd-search-results-list .item-list > * li {
   margin-bottom: var(--search-results-item-spacing);
   padding-bottom: var(--search-results-item-spacing);
   border-bottom: var(--search-results-list-item-border);
 }
 
-.lgd-search-results-list .search-results > li::marker {
+.lgd-search-results-list .item-list > * li::marker {
   color: var(--search-results-list-item-marker-color);
 }
 

--- a/css/components/sitewide-search.ie11.css
+++ b/css/components/sitewide-search.ie11.css
@@ -1,13 +1,23 @@
+.lgd-search-results-list__header-container {
+  padding: 1rem;
+  border: 1px solid #f3f2f1;
+  border-radius: 4px;
+}
+
+.lgd-search-results-list .view-header {
+  margin-bottom: 1.5rem;
+}
+
 .lgd-search-results-list > * {
   margin-bottom: 1.5rem;
 }
 
-.lgd-search-results-list .search-results > li {
+.lgd-search-results-list .item-list > * li {
   margin-bottom: 2.5rem;
   padding-bottom: 2.5rem;
   border-bottom: 1px solid #f3f2f1;
 }
 
-.lgd-search-results-list .search-results > li::marker {
+.lgd-search-results-list .item-list > * li::marker {
   color: #652c95;
 }

--- a/templates/views/views-view--localgov-sitewide-search--sitewide-search-page.html.twig
+++ b/templates/views/views-view--localgov-sitewide-search--sitewide-search-page.html.twig
@@ -1,0 +1,106 @@
+{#
+/**
+ * @file
+ * Theme override for a main view template.
+ *
+ * Available variables:
+ * - attributes: Remaining HTML attributes for the element.
+ * - css_name: A CSS-safe version of the view name.
+ * - css_class: The user-specified classes names, if any.
+ * - header: The optional header.
+ * - footer: The optional footer.
+ * - rows: The results of the view query, if any.
+ * - empty: The content to display if there are no rows.
+ * - pager: The optional pager next/prev links to display.
+ * - exposed: Exposed widget form/info to display.
+ * - feed_icons: Optional feed icons to display.
+ * - more: An optional link to the next page of results.
+ * - title: Title of the view, only used when displaying in the admin preview.
+ * - title_prefix: Additional output populated by modules, intended to be
+ *   displayed in front of the view title.
+ * - title_suffix: Additional output populated by modules, intended to be
+ *   displayed after the view title.
+ * - attachment_before: An optional attachment view to be displayed before the
+ *   view content.
+ * - attachment_after: An optional attachment view to be displayed after the
+ *   view content.
+ * - dom_id: Unique id for every view being printed to give unique class for
+ *   Javascript.
+ *
+ * @see template_preprocess_views_view()
+ */
+#}
+
+{{ attach_library('localgov_base/sitewide-search') }}
+
+{%
+  set classes = [
+    'lgd-search-results-list',
+    'view',
+    'view-' ~ id|clean_class,
+    'view-id-' ~ id,
+    'view-display-id-' ~ display_id,
+    dom_id ? 'js-view-dom-id-' ~ dom_id,
+  ]
+%}
+
+<div{{ attributes.addClass(classes) }}>
+  {{ title_prefix }}
+  {% if title %}
+    {{ title }}
+  {% endif %}
+  {{ title_suffix }}
+
+  {% if header or exposed %}
+    <div class="lgd-search-results-list__header-container">
+      {% if header %}
+        <div class="view-header">
+          {{ header }}
+        </div>
+      {% endif %}
+      {% if exposed %}
+        <div class="view-filters">
+          {{ exposed }}
+        </div>
+      {% endif %}
+    </div>
+  {% endif %}
+
+  {% if attachment_before %}
+    <div class="attachment attachment-before">
+      {{ attachment_before }}
+    </div>
+  {% endif %}
+
+  {% if rows %}
+    <div class="view-content">
+      {{ rows }}
+    </div>
+  {% elseif empty %}
+    <div class="view-empty">
+      {{ empty }}
+    </div>
+  {% endif %}
+
+  {% if pager %}
+    {{ pager }}
+  {% endif %}
+  {% if attachment_after %}
+    <div class="attachment attachment-after">
+      {{ attachment_after }}
+    </div>
+  {% endif %}
+  {% if more %}
+    {{ more }}
+  {% endif %}
+  {% if footer %}
+    <div class="view-footer">
+      {{ footer }}
+    </div>
+  {% endif %}
+  {% if feed_icons %}
+    <div class="feed-icons">
+      {{ feed_icons }}
+    </div>
+  {% endif %}
+</div>


### PR DESCRIPTION
Looks like we are not attaching our sitewide search library to our theme, and even if we were, we could still make things look a lot nicer by default.

## Before:

![Screenshot 2022-08-09 at 12 55 23](https://user-images.githubusercontent.com/2183332/183642250-2dbcfac7-f246-43e6-a023-93f6a4ffc4a7.jpg)

## After:

![Screenshot 2022-08-09 at 12 58 19](https://user-images.githubusercontent.com/2183332/183642285-59eb696c-c4b5-437c-bc1a-fa5adba1011b.jpg)

