### PR TITLE
If the map has a value is_empty and it's true don't display.

### DIFF
--- a/templates/misc/leaflet-map.html.twig
+++ b/templates/misc/leaflet-map.html.twig
@@ -18,6 +18,7 @@
  */
 #}
 
-{{ attach_library('localgov_base/leaflet') }}
-
-<div id="{{ map_id }}" style="min-width: 150px; {% if height is not empty %}height: {{ height }}{% endif %}"></div>
+{% if not map.is_empty %}
+  {{ attach_library('localgov_base/leaflet') }}
+  <div id="{{ map_id }}" style="min-width: 150px; {% if height is not empty %}height: {{ height }}{% endif %}"></div>
+{% endif %}


### PR DESCRIPTION
The value is set for views without any location features in localgov_directories_leaflet_map_view_style_alter().

PR https://github.com/localgovdrupal/localgov_directories/pull/239
Fixes https://github.com/localgovdrupal/localgov_directories/issues/229#issuecomment-1271418506