### PR TITLE
Hide the heading level and title fields on the Embed view block

### DIFF
--- a/templates/paragraphs/paragraph--localgov-embed-views.html.twig
+++ b/templates/paragraphs/paragraph--localgov-embed-views.html.twig
@@ -62,7 +62,7 @@
   {% endif %}
 
   <div class="embedded-views__items">
-    {{ content }}
+    {{ content|without('localgov_title', 'localgov_heading_level') }}
   </div>
 
 </div>


### PR DESCRIPTION
https://github.com/localgovdrupal/localgov_paragraphs/pull/84