### PR TITLE
Add CSS to style the link as a button

### DIFF
--- a/css/components/link.css
+++ b/css/components/link.css
@@ -8,3 +8,26 @@
   margin-right: var(--link-icon-margin);
 }
 
+.link--button-style .link-wrapper {
+  padding:
+  var(--button-padding-vertical) var(--button-padding-horizontal)
+  var(--button-padding-vertical) var(--button-padding-horizontal);
+  cursor: pointer;
+  border: var(--border);
+  border-color: var(--button-border-color);
+  border-radius: var(--button-border-radius);
+  background-color: var(--button-bg-color);
+  font-family: var(--button-font-family);
+  font-size: var(--font-size-medium);
+}
+
+.link--button-style a {
+  color: var(--button-text-color);
+}
+
+.link--button-style:focus,
+.link--button-style:hover {
+  text-decoration: underline;
+  color: var(--button-text-color-hover);
+  background-color: var(--button-bg-color-hover);
+}

--- a/css/components/link.css
+++ b/css/components/link.css
@@ -12,7 +12,6 @@
   padding:
   var(--button-padding-vertical) var(--button-padding-horizontal)
   var(--button-padding-vertical) var(--button-padding-horizontal);
-  cursor: pointer;
   border: var(--border);
   border-color: var(--button-border-color);
   border-radius: var(--button-border-radius);

--- a/css/components/link.css
+++ b/css/components/link.css
@@ -19,14 +19,25 @@
   background-color: var(--button-bg-color);
   font-family: var(--button-font-family);
   font-size: var(--font-size-medium);
-}
-
-.link--button-style a {
   color: var(--button-text-color);
 }
 
-.link--button-style:focus,
-.link--button-style:hover {
+.link--button-style .lgd-icon {
+  fill: var(--button-text-color);
+}
+
+.link--button-style:hover .lgd-icon, 
+.link--button-style:focus .lgd-icon {
+  fill: var(--button-text-color-hover);
+}
+
+.link--button-style a {
+  color: inherit;
+  text-decoration: none;
+}
+
+.link--button-style:focus .link-wrapper,
+.link--button-style:hover .link-wrapper {
   text-decoration: underline;
   color: var(--button-text-color-hover);
   background-color: var(--button-bg-color-hover);

--- a/templates/paragraphs/paragraph--localgov-link.html.twig
+++ b/templates/paragraphs/paragraph--localgov-link.html.twig
@@ -45,7 +45,8 @@
     'paragraph',
     'paragraph--type--' ~ paragraph.bundle|clean_class,
     view_mode ? 'paragraph--view-mode--' ~ view_mode|clean_class,
-    not paragraph.isPublished() ? 'paragraph--unpublished'
+    not paragraph.isPublished() ? 'paragraph--unpublished',
+    paragraph.localgov_link_style.value ? 'link--button-style'
   ]
 %}
 
@@ -59,11 +60,13 @@
 
   {% if paragraph.localgov_url.value %}
     <div class="link-wrapper">
-      {% include "@localgov_base/includes/icons/icon.html.twig" with {
-          icon_name: title_icon,
-          icon_classes: 'link-icon',
-        }
-      %}
+      {% if paragraph.localgov_link_style.value != 'button' %}
+        {% include "@localgov_base/includes/icons/icon.html.twig" with {
+            icon_name: title_icon,
+            icon_classes: 'link-icon',
+          }
+        %}
+      {% endif %}
       <div class="link-content">
         <a href="{{ content.localgov_url.content }}">
           {{ content.localgov_title.0 }}
@@ -72,9 +75,9 @@
     </div>
   {% endif %}
 
-  {% if content|without('localgov_url','localgov_title') %}
+  {% if content|without('localgov_url','localgov_title','localgov_link_style') %}
     <div class="link-block__content">
-      {{ content|without('localgov_url','localgov_title') }}
+      {{ content|without('localgov_url','localgov_title','localgov_link_style') }}
     </div>
   {% endif %}
 

--- a/templates/paragraphs/paragraph--localgov-link.html.twig
+++ b/templates/paragraphs/paragraph--localgov-link.html.twig
@@ -60,11 +60,11 @@
 
   {% if paragraph.localgov_url.value %}
     <div class="link-wrapper">
-        {% include "@localgov_base/includes/icons/icon.html.twig" with {
-            icon_name: title_icon,
-            icon_classes: 'link-icon',
-          }
-        %}
+      {% include "@localgov_base/includes/icons/icon.html.twig" with {
+          icon_name: title_icon,
+          icon_classes: 'link-icon',
+        }
+      %}
       <div class="link-content">
         <a href="{{ content.localgov_url.content }}">
           {{ content.localgov_title.0 }}

--- a/templates/paragraphs/paragraph--localgov-link.html.twig
+++ b/templates/paragraphs/paragraph--localgov-link.html.twig
@@ -42,11 +42,11 @@
 {%
   set classes = [
     'link',
+    paragraph.localgov_link_style.value ? 'link--' ~ paragraph.localgov_link_style.value ~ 'style',
     'paragraph',
     'paragraph--type--' ~ paragraph.bundle|clean_class,
     view_mode ? 'paragraph--view-mode--' ~ view_mode|clean_class,
     not paragraph.isPublished() ? 'paragraph--unpublished',
-    paragraph.localgov_link_style.value ? 'link--button-style'
   ]
 %}
 

--- a/templates/paragraphs/paragraph--localgov-link.html.twig
+++ b/templates/paragraphs/paragraph--localgov-link.html.twig
@@ -42,7 +42,7 @@
 {%
   set classes = [
     'link',
-    paragraph.localgov_link_style.value ? 'link--' ~ paragraph.localgov_link_style.value ~ 'style',
+    paragraph.localgov_link_style.value ? 'link--' ~ paragraph.localgov_link_style.value ~ '-style',
     'paragraph',
     'paragraph--type--' ~ paragraph.bundle|clean_class,
     view_mode ? 'paragraph--view-mode--' ~ view_mode|clean_class,

--- a/templates/paragraphs/paragraph--localgov-link.html.twig
+++ b/templates/paragraphs/paragraph--localgov-link.html.twig
@@ -60,13 +60,11 @@
 
   {% if paragraph.localgov_url.value %}
     <div class="link-wrapper">
-      {% if paragraph.localgov_link_style.value != 'button' %}
         {% include "@localgov_base/includes/icons/icon.html.twig" with {
             icon_name: title_icon,
             icon_classes: 'link-icon',
           }
         %}
-      {% endif %}
       <div class="link-content">
         <a href="{{ content.localgov_url.content }}">
           {{ content.localgov_title.0 }}


### PR DESCRIPTION
- Use the value of the `localgov_link_style` to add a class `link--button-style` when the button option is selected.
- Apply the design used in `form-items.css`.

Relates [Link paragraph: optionally display as a button style #92 ](https://github.com/localgovdrupal/localgov_paragraphs/issues/92)