### PR TITLE
2022 w50 remove extraneous tabs from twig files

### DIFF
--- a/templates/block/guides-prev-next-block.html.twig
+++ b/templates/block/guides-prev-next-block.html.twig
@@ -13,17 +13,17 @@
 %}
 
 {% if not localgov_base_remove_css %}
-	{{ attach_library('localgov_base/prev-next') }}
+  {{ attach_library('localgov_base/prev-next') }}
 {% endif %}
 
 {% set previous_icon = 'chevron-left' %}
 {% set next_icon = 'chevron-right' %}
 
 <nav{{attributes.addClass(classes)}}>
-	<ul class="lgd-prev-next__list">
-		{% if previous_url %}
-			<li class="lgd-prev-next__list-item lgd-prev-next__list-item--prev">
-				<a href="{{ previous_url }}" class="lgd-prev-next__link lgd-prev-next__link--prev" aria-label="{{ 'Previous'|t }}: {{ previous_title }}">
+  <ul class="lgd-prev-next__list">
+    {% if previous_url %}
+      <li class="lgd-prev-next__list-item lgd-prev-next__list-item--prev">
+        <a href="{{ previous_url }}" class="lgd-prev-next__link lgd-prev-next__link--prev" aria-label="{{ 'Previous'|t }}: {{ previous_title }}">
           {% include "@localgov_base/includes/icons/icon.html.twig" with {
               icon_name: previous_icon,
               icon_classes: 'lgd-prev-next__icon lgd-prev-next__icon--prev',
@@ -31,11 +31,11 @@
           %}
           {{ 'Previous'|t }}
         </a>
-			</li>
-		{% endif %}
-		{% if next_url %}
-			<li class="lgd-prev-next__list-item lgd-prev-next__list-item--next">
-				<a href="{{ next_url }}" class="lgd-prev-next__link lgd-prev-next__link--next" aria-label="{{ 'Next'|t }}: {{ next_title }}">
+      </li>
+    {% endif %}
+    {% if next_url %}
+      <li class="lgd-prev-next__list-item lgd-prev-next__list-item--next">
+        <a href="{{ next_url }}" class="lgd-prev-next__link lgd-prev-next__link--next" aria-label="{{ 'Next'|t }}: {{ next_title }}">
           {{ 'Next'|t }}
           {% include "@localgov_base/includes/icons/icon.html.twig" with {
               icon_name: next_icon,
@@ -43,7 +43,7 @@
             }
           %}
         </a>
-			</li>
-		{% endif %}
-	</ul>
+      </li>
+    {% endif %}
+  </ul>
 </nav>

--- a/templates/layout/header.html.twig
+++ b/templates/layout/header.html.twig
@@ -4,70 +4,70 @@
 {% endif %}
 
 <header class="lgd-header">
-	<div class="lgd-container">
-		<div class="lgd-row">
-			<div class="lgd-row__full">
-				<div class="lgd-header__inner">
+  <div class="lgd-container">
+    <div class="lgd-row">
+      <div class="lgd-row__full">
+        <div class="lgd-header__inner">
 
-					{{ page.header }}
+          {{ page.header }}
 
           {% if has_primary_menu or has_search or has_secondary_menu %}
-						{# 
-							The "Header Toggles" section sets a number of buttons to activate 
-							- the primary menu/search regions on small screens, and
-							- the secondary region on all screen sizes (region where we expect
-								the services menu will be positioned).
-						#}
-						<div class="lgd-header__toggles">
-							{% if has_secondary_menu %}
-								<button 
-									class="lgd-header__toggle lgd-header__toggle--secondary" 
-									data-target="lgd-header__nav--secondary" 
-									aria-controls="lgd-header__nav--secondary" 
-									aria-expanded="false" 
-									aria-label="{{ 'Toggle services menu'|t }}"
-								>
-									<span class="lgd-header__toggle-text lgd-header__toggle-text--secondary">{{ 'Services'|t }}</span>
-									<span class="lgd-header__toggle-icon lgd-header__toggle-icon--secondary"></span>
-								</button>
-							{% endif %}
+            {# 
+              The "Header Toggles" section sets a number of buttons to activate 
+              - the primary menu/search regions on small screens, and
+              - the secondary region on all screen sizes (region where we expect
+                the services menu will be positioned).
+            #}
+            <div class="lgd-header__toggles">
+              {% if has_secondary_menu %}
+                <button 
+                  class="lgd-header__toggle lgd-header__toggle--secondary" 
+                  data-target="lgd-header__nav--secondary" 
+                  aria-controls="lgd-header__nav--secondary" 
+                  aria-expanded="false" 
+                  aria-label="{{ 'Toggle services menu'|t }}"
+                >
+                  <span class="lgd-header__toggle-text lgd-header__toggle-text--secondary">{{ 'Services'|t }}</span>
+                  <span class="lgd-header__toggle-icon lgd-header__toggle-icon--secondary"></span>
+                </button>
+              {% endif %}
 
-							{% if has_primary_menu or has_search %}
-								<button 
-									class="lgd-header__toggle lgd-header__toggle--primary" 
-									data-target="lgd-header__nav--primary" 
-									aria-controls="lgd-header__nav--primary" 
-									aria-expanded="false"
-									aria-label="{{ 'Toggle Primary Navigation'|t }}"
-								>
-									<span class="lgd-header__toggle-text lgd-header__toggle-text--primary">{{ 'Menu'|t }}</span>
-									<span class="lgd-header__toggle-icon lgd-header__toggle-icon--primary"></span>
-								</button>
-							{% endif %}
-						</div>
-						
-						{% if has_primary_menu or has_search %}
-							<div id="lgd-header__nav--primary" class="lgd-header__nav lgd-header__nav--primary">
-								{% if has_primary_menu %}
-									{{ page.primary_menu }}
-								{% endif %}
+              {% if has_primary_menu or has_search %}
+                <button 
+                  class="lgd-header__toggle lgd-header__toggle--primary" 
+                  data-target="lgd-header__nav--primary" 
+                  aria-controls="lgd-header__nav--primary" 
+                  aria-expanded="false"
+                  aria-label="{{ 'Toggle Primary Navigation'|t }}"
+                >
+                  <span class="lgd-header__toggle-text lgd-header__toggle-text--primary">{{ 'Menu'|t }}</span>
+                  <span class="lgd-header__toggle-icon lgd-header__toggle-icon--primary"></span>
+                </button>
+              {% endif %}
+            </div>
+            
+            {% if has_primary_menu or has_search %}
+              <div id="lgd-header__nav--primary" class="lgd-header__nav lgd-header__nav--primary">
+                {% if has_primary_menu %}
+                  {{ page.primary_menu }}
+                {% endif %}
 
-								{% if has_search %}
-									{{ page.search }}
-								{% endif %}
-							</div>
-						{% endif %}
+                {% if has_search %}
+                  {{ page.search }}
+                {% endif %}
+              </div>
+            {% endif %}
 
           {% endif %}
 
-					{% if has_secondary_menu %}
-						<div id="lgd-header__nav--secondary" class="lgd-header__nav lgd-header__nav--secondary">
-							{{ page.secondary_menu }}
-						</div>
-					{% endif %}
+          {% if has_secondary_menu %}
+            <div id="lgd-header__nav--secondary" class="lgd-header__nav lgd-header__nav--secondary">
+              {{ page.secondary_menu }}
+            </div>
+          {% endif %}
 
-				</div>
-			</div>
-		</div>
-	</div>
+        </div>
+      </div>
+    </div>
+  </div>
 </header>

--- a/templates/paragraphs/paragraph--localgov-ia-block.html.twig
+++ b/templates/paragraphs/paragraph--localgov-ia-block.html.twig
@@ -55,10 +55,10 @@
 {% endif %}
 
 <div{{ attributes.addClass(classes)}}>
-	{# Check if we have a title so we don't print an empty H2 #}
+  {# Check if we have a title so we don't print an empty H2 #}
   {% if paragraph.localgov_ia_block_title.value %}
     <h2 class="ia-block__title">
-			{# Don't print a anchor tag unless the title is linked #}
+      {# Don't print a anchor tag unless the title is linked #}
     {% if field_link %}
       <a class="ia-block__title-link" href="{{ field_link }}">{{ paragraph.localgov_ia_block_title.value }}</a>
     {% else %}
@@ -67,10 +67,10 @@
     </h2>
   {% endif %}
 
-	{# 
-		Render the list of links 
-		- this variable is created in localgov_homepage_paragraphs.module 
-	#}
+  {# 
+    Render the list of links 
+    - this variable is created in localgov_homepage_paragraphs.module 
+  #}
   {{ list }}
-	
+  
 </div>

--- a/templates/paragraphs/paragraph--localgov-newsroom-teaser.html.twig
+++ b/templates/paragraphs/paragraph--localgov-newsroom-teaser.html.twig
@@ -66,7 +66,7 @@
 
   {% if paragraph.localgov_newsroom_teaser_summary.value %}
     <div class="newsroom-teaser__summary">
-	    {{ content.localgov_newsroom_teaser_summary }}
+      {{ content.localgov_newsroom_teaser_summary }}
     </div>
   {% endif %}
 

--- a/templates/views/views-view-list--localgov-step-by-step-navigation--prev-next.html.twig
+++ b/templates/views/views-view-list--localgov-step-by-step-navigation--prev-next.html.twig
@@ -37,49 +37,49 @@
 #}
 
 {% if not localgov_base_remove_css %}
-	{{ attach_library('localgov_base/prev-next') }}
+  {{ attach_library('localgov_base/prev-next') }}
 {% endif %}
 
 {% set previous_icon = 'chevron-left' %}
 {% set next_icon = 'chevron-right' %}
 
 <nav class="lgd-prev-next lgd-prev-next--step-by-step" aria-label={{ 'Step-by-step'|t }}>
-	{% set has_wrapper_attributes = attributes.toString() %}
-	{% if has_wrapper_attributes -%}
-		<div{{attributes}}>
-		{% endif %}
-		{% if title %}
-			<h3>{{ title }}</h3>
-		{% endif %}
+  {% set has_wrapper_attributes = attributes.toString() %}
+  {% if has_wrapper_attributes -%}
+    <div{{attributes}}>
+    {% endif %}
+    {% if title %}
+      <h3>{{ title }}</h3>
+    {% endif %}
 
-		<{{list.type}}{{list.attributes.addClass('lgd-prev-next__list') }}>
-			{% if has_prev_step %}
-				<li{{rows[prev_step_index].attributes.addClass('lgd-prev-next__list-item', 'lgd-prev-next__list-item--prev') }}>
-					<a href="{{ path('entity.node.canonical', {'node': prev_step_nid }) }}" class="lgd-prev-next__link lgd-prev-next__link--prev" aria-label="{{ 'Previous step'|t }}: {{ prev_step_title }}">
-						{% include "@localgov_base/includes/icons/icon.html.twig" with {
+    <{{list.type}}{{list.attributes.addClass('lgd-prev-next__list') }}>
+      {% if has_prev_step %}
+        <li{{rows[prev_step_index].attributes.addClass('lgd-prev-next__list-item', 'lgd-prev-next__list-item--prev') }}>
+          <a href="{{ path('entity.node.canonical', {'node': prev_step_nid }) }}" class="lgd-prev-next__link lgd-prev-next__link--prev" aria-label="{{ 'Previous step'|t }}: {{ prev_step_title }}">
+            {% include "@localgov_base/includes/icons/icon.html.twig" with {
                 icon_name: previous_icon,
                 icon_classes: 'lgd-prev-next__icon lgd-prev-next__icon--prev',
               }
             %}
-						{{ prev_step_link_text }}</a>
-				</li>
-			{% endif %}
+            {{ prev_step_link_text }}</a>
+        </li>
+      {% endif %}
 
-			{% if has_next_step %}
-				<li{{rows[next_step_index].attributes.addClass('lgd-prev-next__list-item', 'lgd-prev-next__list-item--next') }}>
-					<a href="{{ path('entity.node.canonical', {'node': next_step_nid }) }}" class="lgd-prev-next__link lgd-prev-next__link--next" aria-label="{{ 'Next step'|t }}: {{ next_step_title }}">
-						{{ next_step_link_text }}
-						{% include "@localgov_base/includes/icons/icon.html.twig" with {
+      {% if has_next_step %}
+        <li{{rows[next_step_index].attributes.addClass('lgd-prev-next__list-item', 'lgd-prev-next__list-item--next') }}>
+          <a href="{{ path('entity.node.canonical', {'node': next_step_nid }) }}" class="lgd-prev-next__link lgd-prev-next__link--next" aria-label="{{ 'Next step'|t }}: {{ next_step_title }}">
+            {{ next_step_link_text }}
+            {% include "@localgov_base/includes/icons/icon.html.twig" with {
                 icon_name: next_icon,
                 icon_classes: 'lgd-prev-next__icon lgd-prev-next__icon--next',
               }
             %}
           </a>
-				</li>
-			{% endif %}
-		</{{list.type}}>
+        </li>
+      {% endif %}
+    </{{list.type}}>
 
-		{% if has_wrapper_attributes -%}
-		</div>
-	{% endif %}
+    {% if has_wrapper_attributes -%}
+    </div>
+  {% endif %}
 </nav>


### PR DESCRIPTION
Minor coding standards fix: replaces all tab characters in *.html.twig files with two spaces.

(I can't find specific references to tabs in Drupal Twig or Twig coding standards, but all one or all the other is better than a mix IMO).


@markconroy: here you go.