### PR TITLE
332 header js does not ensure operations happen only once unnecessary reassignment of context

### DIFF
--- a/js/header.js
+++ b/js/header.js
@@ -68,23 +68,23 @@ if (window.NodeList && !NodeList.prototype.forEach) {
       // Which menu region to show is decided by the "toggleThatWasClicked" parameter.
       function handleToggleClick(toggleThatWasClicked) {
         const currentState = toggleThatWasClicked.getAttribute('aria-expanded');
-        currentState === 'false' ? 
-          toggleThatWasClicked.setAttribute('aria-expanded', 'true') : 
+        currentState === 'false' ?
+          toggleThatWasClicked.setAttribute('aria-expanded', 'true') :
           toggleThatWasClicked.setAttribute('aria-expanded', 'false');
-          
-        toggleThatWasClicked.classList.contains('lgd-header__toggle--active') ? 
+
+        toggleThatWasClicked.classList.contains('lgd-header__toggle--active') ?
           toggleThatWasClicked.classList.remove('lgd-header__toggle--active') :
           toggleThatWasClicked.classList.add('lgd-header__toggle--active');
       }
 
-      // General reset function to hide the menu regions and reset the toggle 
+      // General reset function to hide the menu regions and reset the toggle
       // button attributes.
       function handleReset() {
         headerToggles.forEach(function(headerToggle) {
           headerToggle.setAttribute('aria-expanded', 'false');
           headerToggle.classList.remove('lgd-header__toggle--active');
         });
-        regions.forEach(function(region) { 
+        regions.forEach(function(region) {
           region.classList.remove('lgd-header__nav--active');
         });
       }
@@ -94,7 +94,7 @@ if (window.NodeList && !NodeList.prototype.forEach) {
         handleToggleClick(primaryMenuToggle);
         handleEscKeyClick(primaryMenuToggle);
         regions.forEach(function(region) {
-          region.classList.contains('lgd-header__nav--active') ? 
+          region.classList.contains('lgd-header__nav--active') ?
           region.classList.remove('lgd-header__nav--active') :
           region.classList.add('lgd-header__nav--active');
         });
@@ -104,7 +104,7 @@ if (window.NodeList && !NodeList.prototype.forEach) {
       function handleSecondaryMenuToggleClick() {
         handleToggleClick(secondaryMenuToggle);
         handleEscKeyClick(secondaryMenuToggle);
-        secondaryMenuRegion.classList.contains('lgd-header__nav--active') ? 
+        secondaryMenuRegion.classList.contains('lgd-header__nav--active') ?
         secondaryMenuRegion.classList.remove('lgd-header__nav--active') :
         secondaryMenuRegion.classList.add('lgd-header__nav--active');
         secondaryMenuRegion.classList.contains('lgd-header__nav--active') ? secondaryMenuFirstLink.focus() : null;
@@ -114,7 +114,7 @@ if (window.NodeList && !NodeList.prototype.forEach) {
       // set focus back to the services button
       function handleSecondaryMenuShiftTabClick() {
         secondaryMenuFirstLink.addEventListener('keydown', function(e) {
-          if (e.shiftKey && e.key == 'Tab') { 
+          if (e.shiftKey && e.key == 'Tab') {
             e.preventDefault();
             handleReset();
             secondaryMenuToggle.focus();
@@ -126,7 +126,7 @@ if (window.NodeList && !NodeList.prototype.forEach) {
       function handleEscKeyClick(buttonToFocus) {
         context.addEventListener('keydown', function(e) {
           // When on any link in the secondary menu, if you hit escape
-          // set focus back to: 
+          // set focus back to:
           // 1. menu button on small screens, and
           // 2. services button on large screens
           if (e.key == 'Escape') {
@@ -139,7 +139,7 @@ if (window.NodeList && !NodeList.prototype.forEach) {
 
       // When the window is resized (or a device orientation changes),
       // set out what happens.
-      // On a small screen, the primary button is shown which will show both 
+      // On a small screen, the primary button is shown which will show both
       // menu regions when clicked.
       // On a large screen, the secondary button is shown which will show only
       // the secondary menu region when clicked (the primary menu will always be visible).
@@ -157,7 +157,7 @@ if (window.NodeList && !NodeList.prototype.forEach) {
           if (primaryMenuToggle) {
             primaryMenuToggle.removeEventListener('click', handlePrimaryMenuToggleClick, true);
           }
-          if (secondaryMenuToggle) { 
+          if (secondaryMenuToggle) {
             secondaryMenuToggle.addEventListener('click', handleSecondaryMenuToggleClick);
             secondaryMenuToggle.addEventListener('click', handleSecondaryMenuShiftTabClick);
           }
@@ -176,7 +176,7 @@ if (window.NodeList && !NodeList.prototype.forEach) {
           handleWindowResized();
         }
       }
-      
+
       // Call our functions, initially and also when the window is resized.
       handleWindowResized();
       window.addEventListener('resize', Drupal.debounce(handleCheckIfWindowActuallyResized, 50, false));

--- a/js/header.js
+++ b/js/header.js
@@ -11,70 +11,58 @@ if (window.NodeList && !NodeList.prototype.forEach) {
 (function headerScript(Drupal) {
   Drupal.behaviors.header = {
     attach: function (context) {
-      context = context || document;
+      // Hide the search form label. We use .once() to avoid re-running.
+      //
+      // @todo: make it possible to override this without having to maintain a
+      //   *copy* of this file.
+      const headerSearchFormLabel = once('header-search-label', '.lgd-region--search form label', context);
 
-      const headerSearchForm = context.querySelector('.lgd-region--search form');
-      if (headerSearchForm) {
-        headerSearchForm.querySelector('label').classList.add('visually-hidden');
+      if (headerSearchFormLabel.length) {
+        headerSearchFormLabel[0].classList.add('visually-hidden');
       }
 
+      // Set up initial variables, including those we can't define yet.
+      //
+      // We need a bunch of classes and selectors.
+      const headerToggleSelector = '.lgd-header__toggle';
+      const primaryToggleClass = 'lgd-header__toggle--primary';
+      const toggleActiveClass = 'lgd-header__toggle--active';
+      const regionActiveClass = 'lgd-header__nav--active';
+      // This contains all toggles and their corresponding regions.
+      const navInfo = {};
+      // This is used as a check on resize to see if the window size *actually*
+      // changed.
       let windowWidth = window.innerWidth;
+      // All the interactivity here revolves around the toggles, so query them
+      // and we can build an object full of references to them and to their
+      // regions. We use .once() to avoid re-running this.
+      const headerToggles = once('header-toggle', headerToggleSelector, context);
 
-      // Set variables for the regions we need to show/hide
-      const regions = [];
-      let primaryMenuRegion;
-      let secondaryMenuRegion;
-      if (context.querySelector('.lgd-header__nav--primary')) {
-        primaryMenuRegion = context.querySelector('.lgd-header__nav--primary');
-        regions.push(primaryMenuRegion);
-      }
-      if (context.querySelector('.lgd-header__nav--secondary')) {
-        secondaryMenuRegion = context.querySelector('.lgd-header__nav--secondary');
-        regions.push(secondaryMenuRegion);
-      }
-
-      // Set variables for menu toggles
-      const headerToggles = context.querySelectorAll('.lgd-header__toggle');
-      let primaryMenuToggle;
-      let secondaryMenuToggle;
-      if (context.querySelector('.lgd-header__toggle--primary')) {
-        primaryMenuToggle = context.querySelector('.lgd-header__toggle--primary');
-      }
-      if (context.querySelector('.lgd-header__toggle--secondary')) {
-        secondaryMenuToggle = context.querySelector('.lgd-header__toggle--secondary');
-      }
-
-      // If there are no menu toggle buttons present,
-      // get out of here as soon as possible
       if (!headerToggles.length) {
         return;
       }
 
-      headerToggles.forEach(function(headerToggle) {
-        if (headerToggle.classList.contains('js-processed')) {
-          return;
-        } else {
-          headerToggle.classList.add('js-processed');
-        }
-      });
+      // Looping over the discovered menu toggles, create an object containing
+      // references to the various DOM elements we need to work with.
+      headerToggles.forEach(function(toggle) {
+        const region = context.getElementById(toggle.getAttribute('aria-controls'));
+        const nav = toggle.classList.contains(primaryToggleClass)
+          ? 'primary'
+          : 'secondary';
+        // The resulting region.primary.firstLink isn't used, but it's less
+        // difficult to add it than to add only region.secondary.firstLink.
+        const firstLink = region.querySelector('.menu a');
 
-      // Set variables to use later for keyboard navigation
-      let secondaryMenuFirstLink;
-      if (secondaryMenuRegion) {
-        secondaryMenuFirstLink = secondaryMenuRegion.querySelector('.menu a');
-      }
+        navInfo[nav] = { toggle, region, firstLink };
+      });
 
       // When a menu toggle button is clicked, show/hide the menu regions.
       // Which menu region to show is decided by the "toggleThatWasClicked" parameter.
       function handleToggleClick(toggleThatWasClicked) {
-        const currentState = toggleThatWasClicked.getAttribute('aria-expanded');
-        currentState === 'false' ?
-          toggleThatWasClicked.setAttribute('aria-expanded', 'true') :
-          toggleThatWasClicked.setAttribute('aria-expanded', 'false');
+        const currentState = toggleThatWasClicked.getAttribute('aria-expanded') === 'true';
 
-        toggleThatWasClicked.classList.contains('lgd-header__toggle--active') ?
-          toggleThatWasClicked.classList.remove('lgd-header__toggle--active') :
-          toggleThatWasClicked.classList.add('lgd-header__toggle--active');
+        toggleThatWasClicked.setAttribute('aria-expanded', !currentState);
+        toggleThatWasClicked.classList.toggle(toggleActiveClass);
       }
 
       // General reset function to hide the menu regions and reset the toggle
@@ -82,42 +70,45 @@ if (window.NodeList && !NodeList.prototype.forEach) {
       function handleReset() {
         headerToggles.forEach(function(headerToggle) {
           headerToggle.setAttribute('aria-expanded', 'false');
-          headerToggle.classList.remove('lgd-header__toggle--active');
+          headerToggle.classList.remove(toggleActiveClass);
         });
-        regions.forEach(function(region) {
-          region.classList.remove('lgd-header__nav--active');
+
+        Object.keys(navInfo).forEach(function(nav) {
+          navInfo[nav].region.classList.remove(regionActiveClass);
         });
       }
 
       // When the primary menu toggle is clicked
       function handlePrimaryMenuToggleClick() {
+        const primaryMenuToggle = navInfo.primary.toggle;
+
         handleToggleClick(primaryMenuToggle);
         handleEscKeyClick(primaryMenuToggle);
-        regions.forEach(function(region) {
-          region.classList.contains('lgd-header__nav--active') ?
-          region.classList.remove('lgd-header__nav--active') :
-          region.classList.add('lgd-header__nav--active');
+
+        Object.keys(navInfo).forEach(function(nav) {
+          navInfo[nav].region.classList.toggle(regionActiveClass);
         });
       }
 
       // When the secondary menu toggle is clicked
       function handleSecondaryMenuToggleClick() {
-        handleToggleClick(secondaryMenuToggle);
-        handleEscKeyClick(secondaryMenuToggle);
-        secondaryMenuRegion.classList.contains('lgd-header__nav--active') ?
-        secondaryMenuRegion.classList.remove('lgd-header__nav--active') :
-        secondaryMenuRegion.classList.add('lgd-header__nav--active');
-        secondaryMenuRegion.classList.contains('lgd-header__nav--active') ? secondaryMenuFirstLink.focus() : null;
+        handleToggleClick(navInfo.secondary.toggle);
+        handleEscKeyClick(navInfo.secondary.toggle);
+
+        navInfo.secondary.region.classList.toggle(regionActiveClass);
+        navInfo.secondary.region.classList.contains(regionActiveClass)
+          ? navInfo.secondary.firstLink.focus()
+          : null;
       }
 
       // When on the first link in the secondary menu, if you shift+tab
       // set focus back to the services button
       function handleSecondaryMenuShiftTabClick() {
-        secondaryMenuFirstLink.addEventListener('keydown', function(e) {
+        navInfo.secondary.firstLink.addEventListener('keydown', function(e) {
           if (e.shiftKey && e.key == 'Tab') {
             e.preventDefault();
             handleReset();
-            secondaryMenuToggle.focus();
+            navInfo.secondary.toggle.focus();
           }
         });
       }
@@ -145,21 +136,22 @@ if (window.NodeList && !NodeList.prototype.forEach) {
       // the secondary menu region when clicked (the primary menu will always be visible).
       function handleWindowResized() {
         handleReset();
+
         if  (window.innerWidth < 768) {
-          if (secondaryMenuToggle) {
-            secondaryMenuToggle.removeEventListener('click', handleSecondaryMenuToggleClick, true);
-            secondaryMenuToggle.removeEventListener('click', handleSecondaryMenuShiftTabClick, true);
+          if (navInfo.secondary.toggle) {
+            navInfo.secondary.toggle.removeEventListener('click', handleSecondaryMenuToggleClick, true);
+            navInfo.secondary.toggle.removeEventListener('click', handleSecondaryMenuShiftTabClick, true);
           }
-          if (primaryMenuToggle) {
-            primaryMenuToggle.addEventListener('click', handlePrimaryMenuToggleClick);
+          if (navInfo.primary.toggle) {
+            navInfo.primary.toggle.addEventListener('click', handlePrimaryMenuToggleClick);
           }
         } else {
-          if (primaryMenuToggle) {
-            primaryMenuToggle.removeEventListener('click', handlePrimaryMenuToggleClick, true);
+          if (navInfo.primary.toggle) {
+            navInfo.primary.toggle.removeEventListener('click', handlePrimaryMenuToggleClick, true);
           }
-          if (secondaryMenuToggle) {
-            secondaryMenuToggle.addEventListener('click', handleSecondaryMenuToggleClick);
-            secondaryMenuToggle.addEventListener('click', handleSecondaryMenuShiftTabClick);
+          if (navInfo.secondary.toggle) {
+            navInfo.secondary.toggle.addEventListener('click', handleSecondaryMenuToggleClick);
+            navInfo.secondary.toggle.addEventListener('click', handleSecondaryMenuShiftTabClick);
           }
         }
       }

--- a/js/header.js
+++ b/js/header.js
@@ -21,7 +21,7 @@ if (window.NodeList && !NodeList.prototype.forEach) {
         headerSearchFormLabel[0].classList.add('visually-hidden');
       }
 
-      // Set up initial variables, including those we can't define yet.
+      // Set up initial variables.
       //
       // We need a bunch of classes and selectors.
       const headerToggleSelector = '.lgd-header__toggle';
@@ -59,6 +59,7 @@ if (window.NodeList && !NodeList.prototype.forEach) {
       // When a menu toggle button is clicked, show/hide the menu regions.
       // Which menu region to show is decided by the "toggleThatWasClicked" parameter.
       function handleToggleClick(toggleThatWasClicked) {
+        // Get the current state as a boolean.
         const currentState = toggleThatWasClicked.getAttribute('aria-expanded') === 'true';
 
         toggleThatWasClicked.setAttribute('aria-expanded', !currentState);
@@ -80,10 +81,8 @@ if (window.NodeList && !NodeList.prototype.forEach) {
 
       // When the primary menu toggle is clicked
       function handlePrimaryMenuToggleClick() {
-        const primaryMenuToggle = navInfo.primary.toggle;
-
-        handleToggleClick(primaryMenuToggle);
-        handleEscKeyClick(primaryMenuToggle);
+        handleToggleClick(navInfo.primary.toggle);
+        handleEscKeyClick(navInfo.primary.toggle);
 
         Object.keys(navInfo).forEach(function(nav) {
           navInfo[nav].region.classList.toggle(regionActiveClass);

--- a/js/header.js
+++ b/js/header.js
@@ -84,9 +84,7 @@ if (window.NodeList && !NodeList.prototype.forEach) {
         handleToggleClick(navInfo.primary.toggle);
         handleEscKeyClick(navInfo.primary.toggle);
 
-        Object.keys(navInfo).forEach(function(nav) {
-          navInfo[nav].region.classList.toggle(regionActiveClass);
-        });
+        navInfo.primary.region.classList.toggle(regionActiveClass);
       }
 
       // When the secondary menu toggle is clicked

--- a/localgov_base.libraries.yml
+++ b/localgov_base.libraries.yml
@@ -64,6 +64,7 @@ header-js:
   dependencies:
     - core/drupal
     - core/drupal.debounce
+    - core/once
 
 footer:
   css:


### PR DESCRIPTION
This PR's main intention is to address the issues raised in #332, but I've used that as an excuse for streamlining and regularizing the code--but without substantially altering the logic.

Reproducing the commit message from f78af4e, here's a list of the basic changes:

  - trailing whitespace trimmed,
  - whitespace in general attended to,
  - remove a LOT of unnecessary querySelector() calls,
  - consolidate most-used DOM references in navInfo variable,
  - regularize ternaries (there were three or more styles in use),
  - eliminate several element.classList .contains() / .add() / .remove()
    ternaries via the use of element.classList.toggle(),
  - collect variables declarations/assignments at the beginning of the file,
  - separate the header search label manipulation from the nav/button work,
  - use variables instead of repeating class names and selectors,

As far as I can see, I haven't broken anything :grimacing: 

Incidentally, for reviewers, I didn't mention this specifically in commit messages, but I've changed all instances of this structure:

```js
      let foo;
      let bar;
      if (context.querySelector('.foo')) {
        foo = context.querySelector('.foo');
      }
      if (context.querySelector('.bar')) {
        bar = context.querySelector('.bar');
      }
```

...to this structure:

```js
  const foo = context.querySelector('.foo');
  const bar = context.querySelector('.bar');
```

...because:

  - it's shorter,
  - these variables are never redefined (i.e. `const`, not `let`),
  - it's more efficient (half the `querySelector()` calls),
  - the result if the DOM element is missing is similar (now the result will be ~empty `NodeList` objects~ `null` instead of `undefined` ~variables~)