### PR TITLE
Makes sure primary toggle toggles both nav regions

### DIFF
--- a/js/header.js
+++ b/js/header.js
@@ -85,6 +85,7 @@ if (window.NodeList && !NodeList.prototype.forEach) {
         handleEscKeyClick(navInfo.primary.toggle);
 
         navInfo.primary.region.classList.toggle(regionActiveClass);
+        navInfo.secondary.region.classList.toggle(regionActiveClass);
       }
 
       // When the secondary menu toggle is clicked


### PR DESCRIPTION
This PR should restore the functionality broken by #334.

- Re: 352-in-header-js-primary-toggle-now-only-toggles-primary-nav