### PR TITLE
Remove our focus state from toolbar items

### DIFF
--- a/css/base/base.css
+++ b/css/base/base.css
@@ -51,14 +51,13 @@ a:hover {
   text-decoration-thickness: max(3px, 0.1875rem, 0.12em);
 }
 
-a:focus {
+a:not(.toolbar a):focus {
   text-decoration: none;
   color: var(--color-black);
   outline: 3px solid transparent;
   background-color: var(--color-focus);
-  -webkit-box-shadow: 0 -2px var(--color-focus), 0 4px var(--color-black);
   box-shadow: 0 -2px var(--color-focus), 0 4px var(--color-black);
-  -webkit-box-decoration-break: clone;
+  box-decoration-break: clone;
 }
 
 h1,

--- a/css/components/admin-toolbar.css
+++ b/css/components/admin-toolbar.css
@@ -1,3 +1,8 @@
 .toolbar-menu {
   font-size: 0.8125rem;
 }
+
+.toolbar .toolbar-bar .toolbar-item:focus {
+    background-color: transparent;
+    box-shadow: none;
+}


### PR DESCRIPTION
Removes the effect of our focus state from admin toolbar items, to resolve the color contrast issue in #391.

The default focus states are not amazing (and I'm not sure they'd meet the new requirements in WCAG 2.2) but I think they're WCAG 2.1 AA compliant, and definitely better than the white-on-yellow text we have now.

An alternative approach would be to apply our focus states correctly, however, this would require some modifications to the icons on these menus so that they meet colour contrast requirements in the focus state too.

Before:

<img width="380" alt="Screenshot 2023-03-04 at 08 36 18" src="https://user-images.githubusercontent.com/19519457/222889584-50121625-4941-4e4c-af07-ce1742dd764d.png">

After:

<img width="380" alt="Screenshot 2023-03-04 at 09 12 26" src="https://user-images.githubusercontent.com/19519457/222889598-f0283096-dbce-4878-ae57-7a431a4f547c.png">
