### PR TITLE
Focus states on step by step navigation consistent with others in localgov_base

### DIFF
--- a/css/components/step-by-step.css
+++ b/css/components/step-by-step.css
@@ -34,3 +34,15 @@
 .block-views-blocklocalgov-step-by-step-navigation-steps-for-overview {
   max-width: var(--step-by-step-nav-block-width);
 }
+
+/* Focus states on step by step navigation buttons */
+.step-by-step-pages .step-master:focus, .step-by-step-pages .step-master:hover, .step-by-step-pages .step-master:active, .step-by-step-pages ol.step-list .step .step__title .step-show:focus, .step-by-step-pages ol.step-list .step .step__title .step-show:hover, .step-by-step-pages ol.step-list .step .step__title .step-show:active {
+    text-decoration: none;
+    color: var(--color-black);
+    outline: 3px solid transparent;
+    background-color: var(--color-focus);
+    -webkit-box-shadow: 0 -2px var(--color-focus),0 4px var(--color-black);
+    box-shadow: 0 -2px var(--color-focus),0 4px var(--color-black);
+    -webkit-box-decoration-break: clone;
+}
+

--- a/css/components/step-by-step.css
+++ b/css/components/step-by-step.css
@@ -36,7 +36,12 @@
 }
 
 /* Focus states on step by step navigation buttons */
-.step-by-step-pages .step-master:focus, .step-by-step-pages .step-master:hover, .step-by-step-pages .step-master:active, .step-by-step-pages ol.step-list .step .step__title .step-show:focus, .step-by-step-pages ol.step-list .step .step__title .step-show:hover, .step-by-step-pages ol.step-list .step .step__title .step-show:active {
+.step-by-step-pages .step-master:focus,
+.step-by-step-pages .step-master:hover,
+.step-by-step-pages .step-master:active,
+.step-by-step-pages ol.step-list .step .step__title .step-show:focus,
+.step-by-step-pages ol.step-list .step .step__title .step-show:hover,
+.step-by-step-pages ol.step-list .step .step__title .step-show:active {
     text-decoration: none;
     color: var(--color-black);
     outline: 3px solid transparent;


### PR DESCRIPTION
I've copied the selectors from localgov_step_by_step because if I just apply `button:focus`, it still gets overridden by those styles.

New version:
![image](https://user-images.githubusercontent.com/19519457/222894753-e6eb10de-5488-4ec8-8933-d1dc69946e7b.png)

Resolves #393 