### PR TITLE
Add extend for cookie compliance module

### DIFF
--- a/css/components/localgov_eu_cookie_compliance.css
+++ b/css/components/localgov_eu_cookie_compliance.css
@@ -1,0 +1,18 @@
+/*
+  @file Theming for localgovdrupal/localgov_eu_cookie_compliance
+  
+  This has been included to avoid the cookie compliance integration
+  having a dependency on the base theme's variables for styling. By
+  including this here, there will be sensible behaviour out-of-the-box.
+  
+  End-users can override these styles in their decendent themes, if needed.
+
+  This uses the .lgd-region path to increase specificity over that
+  included in the compliance module, as when using LGD this is
+  rendered within .lgd-region.lgd-region--content-top
+*/ 
+
+.lgd-region .eu-cookie-compliance-save-preferences-button.spinning::before {
+    box-shadow: 0 0 2px 0 var(--button-text-color-hover);
+    border-right: 3px solid var(--button-text-color-hover);
+}

--- a/css/components/localgov_eu_cookie_compliance.css
+++ b/css/components/localgov_eu_cookie_compliance.css
@@ -5,7 +5,7 @@
   having a dependency on the base theme's variables for styling. By
   including this here, there will be sensible behaviour out-of-the-box.
   
-  End-users can override these styles in their decendent themes, if needed.
+  End-users can override these styles in their descendant themes, if needed.
 
   This uses the .lgd-region path to increase specificity over that
   included in the compliance module, as when using LGD this is

--- a/localgov_base.info.yml
+++ b/localgov_base.info.yml
@@ -29,3 +29,7 @@ regions:
   lower_footer_second: "Lower footer second"
   lower_footer_third: "Lower footer third"
   disabled: "Disabled"
+
+libraries-extend:
+  localgov_eu_cookie_compliance/localgov_eu_cookie_compliance:
+    - localgov_base/localgov_eu_cookie_compliance

--- a/localgov_base.libraries.yml
+++ b/localgov_base.libraries.yml
@@ -273,3 +273,8 @@ embedded-views:
   css:
     theme:
       css/components/embedded-views.css: {}
+
+localgov_eu_cookie_compliance:
+  css:
+    theme:
+      css/components/localgov_eu_cookie_compliance.css: {}


### PR DESCRIPTION
This extends the `localgov_eu_cookie_compliance` module to add the additional CSS to integrate it with the base theme.

This is a counterpart to https://github.com/localgovdrupal/localgov_eu_cookie_compliance/pull/4