### PR TITLE
fixes header toggles not working when empty regions

### DIFF
--- a/js/header.js
+++ b/js/header.js
@@ -45,9 +45,10 @@
           : 'secondary';
         // The resulting region.primary.firstLink isn't used, but it's less
         // difficult to add it than to add only region.secondary.firstLink.
-        const firstLink = region.querySelector('.menu a');
-
-        navInfo[nav] = { toggle, region, firstLink };
+        if (region) {
+          const firstLink = region.querySelector('.menu a');
+          navInfo[nav] = { toggle, region, firstLink };
+        }
       });
 
       // When a menu toggle button is clicked, show/hide the menu regions.
@@ -138,7 +139,7 @@
             navInfo.primary.toggle.addEventListener('click', handlePrimaryMenuToggleClick);
           }
         } else {
-          if (navInfo.primary.toggle) {
+          if (Object.keys(navInfo).includes('primary') && navInfo.primary.toggle) {
             navInfo.primary.toggle.removeEventListener('click', handlePrimaryMenuToggleClick, true);
           }
           if (Object.keys(navInfo).includes('secondary') && navInfo.secondary.toggle) {

--- a/localgov_base.theme
+++ b/localgov_base.theme
@@ -5,9 +5,9 @@
  * Theme hooks to support the LocalGov Base Theme.
  */
 
+use Drupal\Component\Utility\Crypt;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\views\ViewExecutable;
-use Drupal\Component\Utility\Crypt;
 
 /**
  * Implements hook_form_system_theme_settings_alter().


### PR DESCRIPTION
Closes #452 

To test:
- Remove blocks from Search and Primary Nav regions, so that region will not be rendering
- The "Services" toggle should stop working as the JS will break looking for a 'primary' key for 'region'
- Add this PR which does a check for primary before calling it's code, skips it when it's not found, and continues to work