### PR TITLE
Add alert-success style

### DIFF
--- a/css/base/ckeditor.css
+++ b/css/base/ckeditor.css
@@ -30,6 +30,10 @@
   border-color: #ed7522;
 }
 
+.alert-success {
+  border-color: #048a04;
+}
+
 /* Links */
 .btn.btn-start {
   padding: 0.5rem 1rem;

--- a/css/components/wysiwyg-styles.css
+++ b/css/components/wysiwyg-styles.css
@@ -28,6 +28,10 @@
   border-color: var(--color-warning);
 }
 
+.alert-success {
+  border-color: var(--color-success);
+}
+
 /* Links */
 .btn.btn-start {
   display: inline-flex;


### PR DESCRIPTION
Looks like alert-success style was missing, so let's add them.

I don't know why `ckeditor.css` doesn't use variables, but I assume there's a good reason, so I've followed the same pattern.

Fixes #460 