### PR TITLE
Enhance focus states for input, textarea and select #459

### DIFF
--- a/css/components/form-items.css
+++ b/css/components/form-items.css
@@ -63,7 +63,7 @@ input[type="text"]:focus,
 input[type="url"]:focus,
 textarea:focus,
 select:focus {
-  outline: 3px solid var(--color-yellow);
+  outline: 3px solid var(--color-focus);
   outline-offset: 0;
   box-shadow: inset 0 0 0 3px;
   border-color: var(--color-black);

--- a/css/components/form-items.css
+++ b/css/components/form-items.css
@@ -52,6 +52,23 @@ select,
   font-size: var(--font-size-medium);
 }
 
+input[type="date"]:focus,
+input[type="datetime-local"]:focus,
+input[type="email"]:focus,
+input[type="number"]:focus,
+input[type="password"]:focus,
+input[type="search"]:focus,
+input[type="tel"]:focus,
+input[type="text"]:focus,
+input[type="url"]:focus,
+textarea:focus,
+select:focus {
+  outline: 3px solid #fd0;
+  outline-offset: 0;
+  box-shadow: inset 0 0 0 3px;
+  border-color: var(--color-black);
+}
+
 .select2-container--default .select2-selection--single {
   display: flex;
   align-items: center;

--- a/css/components/form-items.css
+++ b/css/components/form-items.css
@@ -63,7 +63,7 @@ input[type="text"]:focus,
 input[type="url"]:focus,
 textarea:focus,
 select:focus {
-  outline: 3px solid #fd0;
+  outline: 3px solid var(--color-yellow);
   outline-offset: 0;
   box-shadow: inset 0 0 0 3px;
   border-color: var(--color-black);


### PR DESCRIPTION
Adding GDS-style focus states for input, textarea and select fields.

I've left the border in the unfocused state the same but just applied the enhanced focus indicators.

This should make it more consistent with the other focus states for radios and checkboxes.

Closes #459.