### PR TITLE
422 show titles of previousnext pages in guide navigation buttonslinks

### DIFF
--- a/css/components/guide-nav.css
+++ b/css/components/guide-nav.css
@@ -37,25 +37,3 @@
   margin-top: var(--spacing-largest);
   margin-bottom: var(--spacing-largest);
 }
-
-.lgd-prev-next__link {
-  flex-wrap: wrap;
-  padding: var(--spacing-smaller);
-  text-decoration: none;
-}
-
-.lgd-prev-next__label {
-  font-weight: bold;
-}
-
-.lgd-prev-next__icon {
-  margin-top: var(--spacing-smallest);
-}
-
-.lgd-prev-next__title {
-  width: 100%;
-}
-
-.lgd-prev-next__list-item--prev .lgd-prev-next__title {
-  padding-left: var(--spacing-large);
-}

--- a/css/components/guide-nav.css
+++ b/css/components/guide-nav.css
@@ -24,3 +24,42 @@
   display: inline;
   font-weight: bold;
 }
+
+.lgd-guide-nav__list-item--active {
+  font-weight: bold;
+}
+
+.lgd-guide-nav__list-item > a {
+  font-weight: normal;
+}
+
+.block-localgov-guides-contents {
+  margin-top: var(--spacing-largest);
+  margin-bottom: var(--spacing-largest);
+}
+
+.lgd-prev-next__link {
+  flex-wrap: wrap;
+  padding: var(--spacing-smaller);
+  text-decoration: none;
+}
+
+.lgd-prev-next__link  > .lgd-prev-next__label {
+  font-weight: bold;
+}
+
+a.lgd-prev-next__link .lgd-prev-next__label {
+  font-weight: bold;
+}
+
+.lgd-prev-next__icon {
+  margin-top: 3px;
+}
+
+.lgd-prev-next__title {
+  width: 100%;
+}
+
+.lgd-prev-next__list-item--prev .lgd-prev-next__title {
+  padding-left: var(--spacing-large);
+}

--- a/css/components/guide-nav.css
+++ b/css/components/guide-nav.css
@@ -44,16 +44,12 @@
   text-decoration: none;
 }
 
-.lgd-prev-next__link  > .lgd-prev-next__label {
-  font-weight: bold;
-}
-
-a.lgd-prev-next__link .lgd-prev-next__label {
+.lgd-prev-next__label {
   font-weight: bold;
 }
 
 .lgd-prev-next__icon {
-  margin-top: 3px;
+  margin-top: var(--spacing-smallest);
 }
 
 .lgd-prev-next__title {

--- a/css/components/prev-next.css
+++ b/css/components/prev-next.css
@@ -13,6 +13,8 @@ ul.lgd-prev-next__list li.lgd-prev-next__list-item {
 
 .lgd-prev-next__link {
   display: flex;
+  flex-wrap: wrap;
+  text-decoration: none;
   align-items: center;
   padding: var(--button-padding-vertical) var(--button-padding-horizontal) var(--button-padding-vertical) var(--button-padding-horizontal);
   color: var(--button-text-color);
@@ -26,6 +28,18 @@ ul.lgd-prev-next__list li.lgd-prev-next__list-item {
 .lgd-prev-next__link:hover {
   color: var(--button-text-color-hover);
   background-color: var(--button-bg--color-hover);
+}
+
+.lgd-prev-next__label {
+  font-weight: bold;
+}
+
+.lgd-prev-next__title {
+  width: 100%;
+}
+
+.lgd-prev-next__list-item--prev .lgd-prev-next__title {
+  padding-left: var(--spacing-large);
 }
 
 .lgd-prev-next__icon path {

--- a/templates/block/guides-prev-next-block.html.twig
+++ b/templates/block/guides-prev-next-block.html.twig
@@ -7,9 +7,9 @@
 
 {%
   set classes = [
-    'lgd-prev-next',
-    'lgd-prev-next--guides',
-  ]
+  'lgd-prev-next',
+  'lgd-prev-next--guides',
+]
 %}
 
 {% if not localgov_base_remove_css %}
@@ -18,32 +18,47 @@
 
 {% set previous_icon = 'chevron-left' %}
 {% set next_icon = 'chevron-right' %}
-
+{{ kint(show_title) }}
 <nav{{attributes.addClass(classes)}}>
   <ul class="lgd-prev-next__list">
     {% if previous_url %}
       <li class="lgd-prev-next__list-item lgd-prev-next__list-item--prev">
         <a href="{{ previous_url }}#lgd-guides__title" class="lgd-prev-next__link lgd-prev-next__link--prev" aria-label="{{ 'Previous'|t }}: {{ previous_title }}">
           {% include "@localgov_base/includes/icons/icon.html.twig" with {
-              icon_name: previous_icon,
-              icon_classes: 'lgd-prev-next__icon lgd-prev-next__icon--prev',
-            }
+            icon_name: previous_icon,
+            icon_classes: 'lgd-prev-next__icon lgd-prev-next__icon--prev',
+          }
           %}
-          {{ 'Previous'|t }}
+          <div class="lgd-prev-next__label">
+            {{ 'Previous'|t }}
+          </div>
+          {% if show_title == 1 %}
+            <div class="lgd-prev-next__title">
+              {{ previous_title }}
+            </div>
+          {% endif %}
         </a>
       </li>
     {% endif %}
     {% if next_url %}
       <li class="lgd-prev-next__list-item lgd-prev-next__list-item--next">
         <a href="{{ next_url }}#lgd-guides__title" class="lgd-prev-next__link lgd-prev-next__link--next" aria-label="{{ 'Next'|t }}: {{ next_title }}">
-          {{ 'Next'|t }}
+          <div class="lgd-prev-next__label">
+            {{ 'Next'|t }}
+          </div>
           {% include "@localgov_base/includes/icons/icon.html.twig" with {
-              icon_name: next_icon,
-              icon_classes: 'lgd-prev-next__icon lgd-prev-next__icon--next',
-            }
+            icon_name: next_icon,
+            icon_classes: 'lgd-prev-next__icon lgd-prev-next__icon--next',
+          }
           %}
+          {% if show_title == 1 %}
+            <div class="lgd-prev-next__title">
+              {{ next_title }}
+            </div>
+          {% endif %}
         </a>
       </li>
     {% endif %}
   </ul>
 </nav>
+{{ kint(show_title) }}

--- a/templates/block/guides-prev-next-block.html.twig
+++ b/templates/block/guides-prev-next-block.html.twig
@@ -18,7 +18,6 @@
 
 {% set previous_icon = 'chevron-left' %}
 {% set next_icon = 'chevron-right' %}
-{{ kint(show_title) }}
 <nav{{attributes.addClass(classes)}}>
   <ul class="lgd-prev-next__list">
     {% if previous_url %}
@@ -61,4 +60,3 @@
     {% endif %}
   </ul>
 </nav>
-{{ kint(show_title) }}


### PR DESCRIPTION
![Notification_Center](https://github.com/localgovdrupal/localgov_base/assets/1036167/57b5141c-f37c-4b65-91f4-df3382802b80)

This is based off @markconroy css / markup approach and has been modified to allow the settings option we have via the block
