### PR TITLE
Makes page header block lede rendering slightly more flexible

### DIFF
--- a/templates/block/localgov-page-header-block.html.twig
+++ b/templates/block/localgov-page-header-block.html.twig
@@ -26,8 +26,12 @@
       <h1 class="lgd-page-title-block__title">{{ title }}</h1>
     {% endif %}
 
-    {% if lede['#value'] %}
-      <p class="lgd-page-title-block__subheader">{{ lede['#value'] }}</p>
+    {% if lede %}
+      {% if lede['#value'] %}
+        <p class="lgd-page-title-block__subheader">{{ lede['#value'] }}</p>
+      {% else %}
+        {{ lede }}
+      {% endif %}
     {% endif %}
 
   </div>


### PR DESCRIPTION
- Retains current rendering, but anticipates that the {{ lede }} render array could have a different structure.
- A forthcoming change to localgovdrupal/localgov_guides may require this.
- See: https://github.com/localgovdrupal/localgov_guides/pull/133
- Re: 491-localgov_base-directly-access-value-property-of-lede-in-localgov-page-header-blockhtmltwig