### PR TITLE
Stops blocks that are assigned to the disabled region being rendered.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,12 +25,12 @@ jobs:
       fail-fast: false
       matrix:
         localgov-version:
-          - '2.x'
+          - '3.x'
         drupal-version:
-          - '~9.3'
+          - '~10.0'
         php-version:
-          - '7.4'
           - '8.1'
+          - '8.2'
 
     steps:
 
@@ -109,12 +109,12 @@ jobs:
       fail-fast: false
       matrix:
         localgov-version:
-          - '2.x'
+          - '3.x'
         drupal-version:
-          - '~9.3'
+          - '~10.0'
         php-version:
-          - '7.4'
           - '8.1'
+          - '8.2'
 
     steps:
 
@@ -145,12 +145,12 @@ jobs:
       fail-fast: false
       matrix:
         localgov-version:
-          - '2.x'
+          - '3.x'
         drupal-version:
-          - '~9.3'
+          - '~10.0'
         php-version:
-          - '7.4'
           - '8.1'
+          - '8.2'
 
     steps:
 
@@ -180,12 +180,12 @@ jobs:
       fail-fast: false
       matrix:
         localgov-version:
-          - '2.x'
+          - '3.x'
         drupal-version:
-          - '~9.3'
+          - '~10.0'
         php-version:
-          - '7.4'
           - '8.1'
+          - '8.2'
 
     steps:
 

--- a/localgov_base.theme
+++ b/localgov_base.theme
@@ -43,22 +43,20 @@ function localgov_base_preprocess_page(&$variables) {
   // @see https://www.drupal.org/node/953034
   // @see https://www.drupal.org/forum/support/module-development-and-code-questions/2016-04-07/drupal-8-regions-with-and-empty#comment-12149518
   $active_theme = \Drupal::service('theme.manager')->getActiveTheme()->getName();
-  $system_region = system_region_list($active_theme, $show = REGIONS_ALL);
+  $regions = array_keys(system_region_list($active_theme, REGIONS_VISIBLE));
 
-  foreach ($system_region as $key => $value) {
-    $region = $key;
-    $has = 'has_' . $region;
+  $excluded_regions = [
+    'messages',
+    'disabled',
+  ];
 
-    $excluded_regions = [
-      'messages',
-    ];
+  foreach ($regions as $region) {
     if (in_array($region, $excluded_regions)) {
       continue;
     }
-
     $copy = $variables['page'][$region];
-    $rendered = Drupal::service('renderer')->renderPlain($copy);
-    $variables[$has] = !empty(trim(strip_tags($rendered, '<drupal-render-placeholder><embed><hr><iframe><img><input><link><object><script><source><style><video>')));
+    $rendered = \Drupal::service('renderer')->renderPlain($copy);
+    $variables['has_' . $region] = !empty(trim(strip_tags($rendered, '<drupal-render-placeholder><embed><hr><iframe><img><input><link><object><script><source><style><video>')));
   }
   $variables['has_sidebars'] = $variables['has_sidebar_first'] || $variables['has_sidebar_second'];
 

--- a/modules/localgov_base_test_support/localgov_base_test_support.info.yml
+++ b/modules/localgov_base_test_support/localgov_base_test_support.info.yml
@@ -1,0 +1,5 @@
+name: "LocalGov Base Test Support"
+description: "Things to help test localgov_base that have to live in a module."
+type: module
+core_version_requirement: ^8.8 || ^9 || ^10
+hidden: true

--- a/modules/localgov_base_test_support/localgov_base_test_support.routing.yml
+++ b/modules/localgov_base_test_support/localgov_base_test_support.routing.yml
@@ -4,4 +4,5 @@ localgov_base_test_support.test_page:
     _controller: '\Drupal\localgov_base_test_support\Controller\TestController::testPage'
     _title: 'Test page'
   requirements:
+    # No access check, as this module is just for testing.
     _access: 'TRUE'

--- a/modules/localgov_base_test_support/localgov_base_test_support.routing.yml
+++ b/modules/localgov_base_test_support/localgov_base_test_support.routing.yml
@@ -1,0 +1,7 @@
+localgov_base_test_support.test_page:
+  path: '/test-page'
+  defaults:
+    _controller: '\Drupal\localgov_base_test_support\Controller\TestController::testPage'
+    _title: 'Test page'
+  requirements:
+    _access: 'TRUE'

--- a/modules/localgov_base_test_support/localgov_base_test_support.services.yml
+++ b/modules/localgov_base_test_support/localgov_base_test_support.services.yml
@@ -1,0 +1,5 @@
+services:
+  localgov_base_test_support.render_test_block_response_subscriber:
+    class: '\Drupal\localgov_base_test_support\EventSubscriber\RenderTestBlockResponseSubscriber'
+    tags:
+      - { name: 'event_subscriber' }

--- a/modules/localgov_base_test_support/src/Controller/TestController.php
+++ b/modules/localgov_base_test_support/src/Controller/TestController.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Drupal\localgov_base_test_support\Controller;
+
+use Drupal\Core\Controller\ControllerBase;
+
+/**
+ * A test controller.
+ */
+class TestController extends ControllerBase {
+
+  /**
+   * Returns a render array for a test page.
+   */
+  public function testPage() {
+    return [
+      '#markup' => $this->t('Hello World!'),
+    ];
+  }
+
+}

--- a/modules/localgov_base_test_support/src/EventSubscriber/RenderTestBlockResponseSubscriber.php
+++ b/modules/localgov_base_test_support/src/EventSubscriber/RenderTestBlockResponseSubscriber.php
@@ -15,7 +15,7 @@ class RenderTestBlockResponseSubscriber implements EventSubscriberInterface {
   /**
    * {@inheritdoc}
    */
-  static function getSubscribedEvents() {
+  public static function getSubscribedEvents() {
     return [
       KernelEvents::RESPONSE => 'addRenderTestBlockHeader',
     ];

--- a/modules/localgov_base_test_support/src/EventSubscriber/RenderTestBlockResponseSubscriber.php
+++ b/modules/localgov_base_test_support/src/EventSubscriber/RenderTestBlockResponseSubscriber.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Drupal\localgov_base_test_support\EventSubscriber;
+
+use Drupal\localgov_base_test_support\Plugin\Block\RenderTestBlock;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Event\ResponseEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+/**
+ * Adds debug info to the Response headers for testing.
+ */
+class RenderTestBlockResponseSubscriber implements EventSubscriberInterface {
+
+  /**
+   * {@inheritdoc}
+   */
+  static function getSubscribedEvents() {
+    return [
+      KernelEvents::RESPONSE => 'addRenderTestBlockHeader',
+    ];
+  }
+
+  /**
+   * Adds a response header to indicate if the RenderTestBlock got built.
+   */
+  public function addRenderTestBlockHeader(ResponseEvent $event) {
+    $headerName = 'X-Render-Test-Block';
+    $headerValue = RenderTestBlock::$built ? 'TRUE' : 'FALSE';
+    $event->getResponse()->headers->set($headerName, $headerValue);
+  }
+
+}

--- a/modules/localgov_base_test_support/src/Plugin/Block/RenderTestBlock.php
+++ b/modules/localgov_base_test_support/src/Plugin/Block/RenderTestBlock.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Drupal\localgov_base_test_support\Plugin\Block;
+
+use Drupal\Core\Block\BlockBase;
+
+/**
+ * Provides a render test block, used by RegionRenderTest.
+ *
+ * @Block(
+ *   id = "render_test_block",
+ *   admin_label = @Translation("Render test block")
+ * )
+ */
+class RenderTestBlock extends BlockBase {
+
+  /**
+   * Records if a block of this class has ever been built.
+   *
+   * This is public so it can be read by RenderTestBlockResponseSubscriber.
+   *
+   * @var bool
+   */
+  public static bool $built = FALSE;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function build() {
+
+    self::$built = TRUE;
+    return [
+      '#markup' => 'This is the output from the render test block.',
+    ];
+  }
+}

--- a/modules/localgov_base_test_support/src/Plugin/Block/RenderTestBlock.php
+++ b/modules/localgov_base_test_support/src/Plugin/Block/RenderTestBlock.php
@@ -33,4 +33,5 @@ class RenderTestBlock extends BlockBase {
       '#markup' => 'This is the output from the render test block.',
     ];
   }
+
 }

--- a/tests/Functional/RegionRenderTest.php
+++ b/tests/Functional/RegionRenderTest.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Drupal\Tests\block_content\Functional;
+
+use Drupal\Tests\BrowserTestBase;
+
+/**
+ * Tests the code in localgov_base_preprocess_page() that renders regions.
+ *
+ * @group localgov_base
+ */
+class RegionRenderTest extends BrowserTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'localgov_base_test_support',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected $profile = 'localgov';
+
+  /**
+   * {@inheritdoc}
+   */
+  protected $defaultTheme = 'localgov_base';
+
+
+  /**
+   * Data provider for ::testRegionRender().
+   */
+  public function blockRegionProvider() {
+    return [
+      [
+       'region' => 'disabled',
+       'rendered' => 'FALSE',
+      ],
+      [
+        'region' => 'sidebar_first',
+        'rendered' => 'TRUE',
+      ]
+    ];
+  }
+
+  /**
+   * Tests that blocks in regions that aren't printed don't get rendered.
+   *
+   * To do this, we place a block provided by the localgov_base_test_support
+   * module into one of the regions. We then load a page, which is a callback
+   * provided by a controller in the same module, that will always load, and
+   * show blocks. Our block class records if an instance of it was built when
+   * the page loads. The module registers an event listener to add if the block
+   * was rendered to the response headers.
+   *
+   * We do all this because the page render runs in a different process to this
+   * test, so we can't just read the value from the class directly.
+   *
+   * @dataProvider blockRegionProvider
+   */
+  public function testRegionRender($region, $rendered) {
+    $this->drupalPlaceBlock('render_test_block', [
+      'region' => $region,
+    ]);
+    $this->drupalGet('/test-page');
+    $this->assertSession()->responseHeaderContains('X-Render-Test-Block', $rendered);
+  }
+
+}

--- a/tests/Functional/RegionRenderTest.php
+++ b/tests/Functional/RegionRenderTest.php
@@ -28,20 +28,19 @@ class RegionRenderTest extends BrowserTestBase {
    */
   protected $defaultTheme = 'localgov_base';
 
-
   /**
    * Data provider for ::testRegionRender().
    */
   public function blockRegionProvider() {
     return [
       [
-       'region' => 'disabled',
-       'rendered' => 'FALSE',
+        'region' => 'disabled',
+        'rendered' => 'FALSE',
       ],
       [
         'region' => 'sidebar_first',
         'rendered' => 'TRUE',
-      ]
+      ],
     ];
   }
 


### PR DESCRIPTION
Added 'disabled' region to the list of regions not to render. Limited region list to visible ones. Moved list of excluded region names out of the loop and simplified vars in the loop.

Fixes #497.