### PR TITLE
Fix status messages and dynamic content

### DIFF
--- a/templates/layout/status-pages/page--403.html.twig
+++ b/templates/layout/status-pages/page--403.html.twig
@@ -1,17 +1,1 @@
-{% extends "@localgov_base/layout/page.html.twig" %}
-
-{% block page_content %}
-  <div class="lgd-container">
-      <div class="lgd-row">
-        <div class="lgd-row__full">
-          <div class="padding-horizontal">
-            <h1>{{ 'Access denied'|t }}</h1>
-            <p>{{ 'You are not authorised to access this page.'|t }}</p>
-            <p>
-              <a href="/user/login">{{ 'Login'|t }}?</a>
-            </p>
-          </div>
-        </div>
-      </div>
-  </div>
-{% endblock %}
+{% extends "@localgov_base/layout/status-pages/page-status.html.twig" %}

--- a/templates/layout/status-pages/page--404.html.twig
+++ b/templates/layout/status-pages/page--404.html.twig
@@ -1,14 +1,1 @@
 {% extends "@localgov_base/layout/status-pages/page-status.html.twig" %}
-
-{% block page_content %}
-  <div class="lgd-container">
-      <div class="lgd-row">
-        <div class="lgd-row__full">
-          <div class="padding-horizontal">
-            <h1>{{ 'Page not found'|t }}</h1>
-            <p>{{ 'The page you are requesting cannot be found.'|t }}</p>
-          </div>
-        </div>
-      </div>
-  </div>
-{% endblock %}


### PR DESCRIPTION
Removes the hard-coded messages in the 403 and 404 pages.

Also changes the 403 page to use the page status template to allow dynamic content.

This relates to issue #535.

I'm going to open an issue and pull request in localgov_core for the other issue identified in that issue. 