### PR TITLE
Add support for layout paragraphs builder on front end

### DIFF
--- a/templates/content/node--full.html.twig
+++ b/templates/content/node--full.html.twig
@@ -148,7 +148,7 @@
       </div>
   </div>
 
-  {% if node.localgov_subsites_content.value %}
+  {% if node.localgov_subsites_content.value or content.localgov_subsites_content['#type'] == 'layout_paragraphs_builder' %}
     {{ content.localgov_subsites_content }}
   {% endif %}
   


### PR DESCRIPTION
Fix #548

Allows the subsites content field formatter to be changed to layout paragraphs builder which then allows subsites to be edited in the front end, even if there are no paragraphs present. This is important if using the front end theme for content editing (eg. Using mercury editor).
