### PR TITLE
adds default styling for tables with headers as columns

### DIFF
--- a/css/base/base.css
+++ b/css/base/base.css
@@ -180,17 +180,15 @@ table {
   border-collapse: collapse;
 }
 
-thead th {
+td,
+th {
   padding: var(--table-padding);
+  border: var(--table-border);
+}
+
+th {
+  border-color: var(--table-header-border-color);
   background-color: var(--table-bg-color);
-}
-
-tbody td {
-  padding: var(--table-padding);
-}
-
-tbody tr {
-  border-bottom: var(--table-border);
 }
 
 input,

--- a/css/base/variables.css
+++ b/css/base/variables.css
@@ -329,6 +329,7 @@ body {
   --table-border: var(--border);
   --table-padding: var(--spacing);
   --table-bg-color: var(--color-grey-light);
+  --table-header-border-color: var(--color-grey-medium);
 
   /* Tabs */
   --tabs-border: var(--border);


### PR DESCRIPTION
Closes #547 

1. Sets border around all cells
2. Creates new variable for border colour for header items
3. Sets background colour on header items, whether they are rows or columns

===
Thanks to [Big Blue Door](https://www.bigbluedoor.net/) for sponsoring my time to work on this.