### PR TITLE
feat: makes core/drupal a global dependency

### DIFF
--- a/localgov_base.libraries.yml
+++ b/localgov_base.libraries.yml
@@ -17,6 +17,7 @@ global:
   # Declare dependencies for other libraries that we want to load
   # on every page.
   dependencies:
+    - core/drupal
     - localgov_base/grid
     - localgov_base/header
     - localgov_base/footer
@@ -63,7 +64,6 @@ header-js:
   js:
     js/header.js: {}
   dependencies:
-    - core/drupal
     - core/drupal.debounce
     - core/once
 
@@ -298,7 +298,6 @@ subsites-menu:
   js:
     js/subsites-menu.js: {}
   dependencies:
-    - core/drupal
     - core/drupal.debounce
 
 localgov_eu_cookie_compliance:

--- a/localgov_base.libraries.yml
+++ b/localgov_base.libraries.yml
@@ -17,7 +17,6 @@ global:
   # Declare dependencies for other libraries that we want to load
   # on every page.
   dependencies:
-    - core/drupal
     - localgov_base/grid
     - localgov_base/header
     - localgov_base/footer
@@ -64,6 +63,7 @@ header-js:
   js:
     js/header.js: {}
   dependencies:
+    - core/drupal
     - core/drupal.debounce
     - core/once
 
@@ -135,6 +135,8 @@ topic-list-builder:
 guides:
   js:
     js/guides.js: {}
+  dependencies:
+    - core/drupal
 
 guide-nav:
   css:
@@ -298,6 +300,7 @@ subsites-menu:
   js:
     js/subsites-menu.js: {}
   dependencies:
+    - core/drupal
     - core/drupal.debounce
 
 localgov_eu_cookie_compliance:


### PR DESCRIPTION
This helps not to break overrides by subthemes that override e.g. localgov_base/header-js without making core/drupal a requirement.

Closes #557