### PR TITLE
Adds icons for callouts and alerts

### DIFF
--- a/css/components/callout.css
+++ b/css/components/callout.css
@@ -2,11 +2,27 @@
   @file Base styles for call out paragraphs / advanced callout div container
 */
 .callout {
+  display: flex;
+  gap: var(--spacing);
   padding: 1.5rem;
-  text-align: center;
+  /* text-align: center; */
   color: var(--color-white);
   font-size: var(--font-size-large);
   font-weight: bold;
+}
+
+.callout::before {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 5rem;
+  height: 2.5rem;
+  padding: var(--spacing-small);
+  content: "!";
+  color: var(--color-black);
+  border-radius: 999rem;
+  background-color: var(--color-white);
+  font-size: 1.5rem;
 }
 
 .callout a {
@@ -26,25 +42,40 @@
 .callout-primary {
   background-color: var(--color-accent);
 }
+.callout-primary::before {
+  color: var(--color-accent);
+}
 
 /* Callout success bg and link colour */
 .callout-success {
   background-color: var(--color-success);
+}
+.callout-success::before {
+  color: var(--color-success);
 }
 
 /* Callout danger bg and link colour */
 .callout-danger {
   background-color: var(--color-danger);
 }
+.callout-danger::before {
+  color: var(--color-danger);
+}
 
 /* Callout teal bg and link colour */
 .callout-teal {
   background-color: teal;
 }
+.callout-teal::before {
+  color: teal;
+}
 
 /* Callout carbon bg and link colour */
 .callout-carbon {
   background-color: var(--color-grey-dark);
+}
+.callout-carbon::before {
+  color: var(--color-grey-dark);
 }
 
 /* Callout yellow bg and link colour */

--- a/css/components/callout.css
+++ b/css/components/callout.css
@@ -5,7 +5,6 @@
   display: flex;
   gap: var(--spacing);
   padding: 1.5rem;
-  /* text-align: center; */
   color: var(--color-white);
   font-size: var(--font-size-large);
   font-weight: bold;

--- a/css/components/wysiwyg-styles.css
+++ b/css/components/wysiwyg-styles.css
@@ -4,6 +4,8 @@
 
 /* Alerts */
 .alert {
+  display: flex;
+  gap: var(--spacing);
   padding: var(--spacing-largest);
   border: var(--border-large);
   border-color: var(--border-color-alert);
@@ -12,24 +14,53 @@
   font-weight: bold;
 }
 
+.alert::before {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 5rem;
+  height: 2.5rem;
+  padding: var(--spacing-small);
+  content: "!";
+  color: var(--color-white);
+  border-radius: 999rem;
+  background-color: var(--color-black);
+  font-size: 1.5rem;
+}
+
 .alert-primary {
   border-color: var(--color-accent);
+}
+.alert-primary::before {
+  background-color: var(--color-accent);
 }
 
 .alert-info {
   border-color: var(--color-info);
 }
+.alert-info::before {
+  background-color: var(--color-info);
+}
 
 .alert-danger {
   border-color: var(--color-danger);
+}
+.alert-danger::before {
+  background-color: var(--color-danger);
 }
 
 .alert-fail {
   border-color: var(--color-warning);
 }
+.alert-fail::before {
+  background-color: var(--color-warning);
+}
 
 .alert-success {
   border-color: var(--color-success);
+}
+.alert-success::before {
+  background-color: var(--color-success);
 }
 
 /* Links */


### PR DESCRIPTION
Closes #531 

Here's a PR to add an icon to alerts and callouts. Just to note a few things:

1. This is a change that councils may not be expecting
2. Are we sure callouts AND alerts should have an icons, not just alerts?
3. Some councils may have already implemented a similar fix like this already, so this might affect what they have done.

Let's make sure we have these as notes in the release notes. Here's a screenshot.

![Screenshot 2024-06-12 at 16 37 05](https://github.com/localgovdrupal/localgov_base/assets/2183332/a5a29ec4-4804-44cc-aac5-c806d45c267b)

===
Thanks to [Big Blue Door](https://www.bigbluedoor.net/) for sponsoring my time to work on this.
