### PR TITLE
fix: Drupal 11 support

### DIFF
--- a/localgov_base.info.yml
+++ b/localgov_base.info.yml
@@ -1,7 +1,7 @@
 name: "LocalGov Base"
 description: "Base theme for LocalGov Drupal sites."
 type: theme
-core_version_requirement: ^8.8 || ^9 || ^10
+core_version_requirement: ^10.1.3 || ^11
 base theme: "stable9"
 ckeditor_stylesheets:
   - css/base/ckeditor.css

--- a/localgov_base.theme
+++ b/localgov_base.theme
@@ -6,6 +6,7 @@
  */
 
 use Drupal\Component\Utility\Crypt;
+use Drupal\Component\Utility\DeprecationHelper;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\views\ViewExecutable;
 
@@ -69,7 +70,16 @@ function localgov_base_preprocess_page(&$variables) {
       continue;
     }
     $copy = $variables['page'][$region];
-    $rendered = \Drupal::service('renderer')->renderPlain($copy);
+
+    /** @var \Drupal\Core\Render\RendererInterface $renderer */
+    $renderer = \Drupal::service('renderer');
+    $rendered = DeprecationHelper::backwardsCompatibleCall(
+      currentVersion: \Drupal::VERSION,
+      deprecatedVersion: '10.3',
+      currentCallable: fn() => $renderer->renderInIsolation($copy),
+      deprecatedCallable: fn() => $renderer->renderPlain($copy),
+    );
+
     $variables['has_' . $region] = strlen(trim(strip_tags($rendered, '<drupal-render-placeholder><embed><hr><iframe><img><input><link><object><script><source><style><video>'))) > 0;
   }
   $variables['has_sidebars'] = $variables['has_sidebar_first'] || $variables['has_sidebar_second'];

--- a/modules/localgov_base_test_support/localgov_base_test_support.info.yml
+++ b/modules/localgov_base_test_support/localgov_base_test_support.info.yml
@@ -1,5 +1,5 @@
 name: "LocalGov Base Test Support"
 description: "Things to help test localgov_base that have to live in a module."
 type: module
-core_version_requirement: ^8.8 || ^9 || ^10
+core_version_requirement: ^10.1.3 || ^11
 hidden: true


### PR DESCRIPTION
- Drops Drupal 8 and 9 support
- Sets the minimum Drupal 10 to 10.1.3 so DeprecationHelper can be used (https://www.drupal.org/node/3379306)
- Added Drupal 11 support