### PR TITLE
adds better focus orders for services button/menu

### DIFF
--- a/js/header.js
+++ b/js/header.js
@@ -47,8 +47,11 @@
         // The resulting region.primary.firstLink isn't used, but it's less
         // difficult to add it than to add only region.secondary.firstLink.
         if (region) {
-          const firstLink = region.querySelector('.menu a');
-          navInfo[nav] = { toggle, region, firstLink };
+          const links = region.querySelectorAll('.menu a');
+          const firstLink = links[0];
+          const lastLink = links[links.length - 1];
+
+          navInfo[nav] = { toggle, region, firstLink, lastLink };
         }
       });
 
@@ -101,11 +104,22 @@
         navInfo.secondary.firstLink.addEventListener('keydown', function(e) {
           if (e.shiftKey && e.key == 'Tab') {
             e.preventDefault();
-            handleReset();
             navInfo.secondary.toggle.focus();
           }
         });
       }
+
+      // When on the last link in the secondary menu, if you hit tab
+      // set focus back to the services button
+      function handleSecondaryMenuTabClick() {
+        navInfo.secondary.lastLink.addEventListener('keydown', function(e) {
+          if (e.key == 'Tab') {
+            e.preventDefault();
+            navInfo.secondary.toggle.focus();
+          }
+        });
+      }
+
 
       // General function for when the ESC is clicked.
       function handleEscKeyClick(buttonToFocus) {
@@ -143,6 +157,7 @@
           if (Object.keys(navInfo).includes('secondary') && navInfo.secondary.toggle) {
             navInfo.secondary.toggle.removeEventListener('click', handleSecondaryMenuToggleClick, true);
             navInfo.secondary.toggle.removeEventListener('click', handleSecondaryMenuShiftTabClick, true);
+            navInfo.secondary.toggle.removeEventListener('click', handleSecondaryMenuTabClick, true);
           }
           if (navInfo.primary.toggle) {
             navInfo.primary.toggle.addEventListener('click', handlePrimaryMenuToggleClick);
@@ -154,6 +169,7 @@
           if (Object.keys(navInfo).includes('secondary') && navInfo.secondary.toggle) {
             navInfo.secondary.toggle.addEventListener('click', handleSecondaryMenuToggleClick);
             navInfo.secondary.toggle.addEventListener('click', handleSecondaryMenuShiftTabClick);
+            navInfo.secondary.toggle.addEventListener('keyup', handleSecondaryMenuTabClick);
           }
         }
       }

--- a/templates/layout/header.html.twig
+++ b/templates/layout/header.html.twig
@@ -25,7 +25,7 @@
                   data-target="lgd-header__nav--secondary"
                   aria-controls="lgd-header__nav--secondary"
                   aria-expanded="false"
-                  aria-label="{{ 'Services: expand and jump to services menu'|t }}"
+                  aria-label="{{ 'Services: jump to services'|t }}"
                 >
                   <span class="lgd-header__toggle-text lgd-header__toggle-text--secondary">{{ 'Services'|t }}</span>
                   <span class="lgd-header__toggle-icon lgd-header__toggle-icon--secondary"></span>


### PR DESCRIPTION
Closes #578 

## What does this change?

- Adds a new function in header.js so that when you click tab after last item in services menu, the focus goes back to the Services toggle button
- When you shift+tab back out of services menu, the services button does not collapse the menu any more
- Changes the aria-label to be more succinct.

## How to test

- Checkout this branch
- Clear you cache
- Tab to services button in header, click it
- Tab through services links ensure that when you tab after the last one it goes back to the services button
- Tab into services menu, shift+tab back out of it, ensure that the services menu does not collapse when you get back to the services button
- Turn on screenreader, check that the aria-label for services button is "Services: jump to services"

---
Thanks to [Big Blue Door](https://www.bigbluedoor.net/) for sponsoring my time to work on this.