### PR TITLE
202408 skiplink ios keyboard

### DIFF
--- a/js/skip-link.js
+++ b/js/skip-link.js
@@ -1,0 +1,26 @@
+/**
+ * @file Handles IOS bug when trying to use skip link with keyboard.
+ */
+
+(function localgovSkiplink(Drupal) {
+  Drupal.behaviors.skiplink = {
+    attach: function (context) {
+      const [anchor] = once('maincontent', '[href="#main-content"]', context);
+      if (!anchor) {
+        return;
+      }
+      anchor.addEventListener('keydown', (e) => {
+        focusContent(e);
+      });
+
+      function focusContent(e) {
+        const { key } = e;
+        if (key === 'Enter') {
+          var mainContent = document.querySelector('#main-content');
+          mainContent.focus();
+          mainContent.setAttribute('tabindex', 0);
+        }
+      }
+    }
+  };
+}(Drupal));

--- a/localgov_base.libraries.yml
+++ b/localgov_base.libraries.yml
@@ -317,3 +317,10 @@ add-to-calendar:
   dependencies:
     - core/drupal
     - core/once
+
+skip-link:
+  js:
+    js/skip-link.js: {}
+  dependencies:
+    - core/drupal
+    - core/once

--- a/localgov_base.theme
+++ b/localgov_base.theme
@@ -197,3 +197,10 @@ function localgov_base_preprocess_container(&$variables) {
 function localgov_base_form_preview_link_entity_form_alter(&$form, $form_state, $form_id) {
   $form['#attached']['library'][''] = 'localgov_base/preview-link';
 }
+
+/**
+ * Implements hook_preprocess_html().
+ */
+function localgov_base_preprocess_html(&$variables) {
+  $variables['#attached']['library'][] = 'localgov_base/skip-link';
+}

--- a/templates/layout/page--moderngov-template.html.twig
+++ b/templates/layout/page--moderngov-template.html.twig
@@ -6,7 +6,9 @@
   {breadcrumb}
 </div>
 
-<main class="main" id="main-content"> {# The "skip to content" link jumps to here. #}
+<main class="main">
+  {# The "skip to content" link jumps to here. #}
+  <a id="main-content" />
 
   <div class="lgd-container">
       <div class="lgd-row">

--- a/templates/layout/page.html.twig
+++ b/templates/layout/page.html.twig
@@ -98,7 +98,9 @@
 
 {{ page.messages }}
 
-<main class="main" id="main-content"> {# The "skip to content" link jumps to here. #}
+<main class="main">
+  {# The "skip to content" link jumps to here. #}
+  <a id="main-content" />
 
   {% if has_content_top %}
     {{ page.content_top }}


### PR DESCRIPTION
## What does this change?

This is a workaround for an IOS/keyboard navigation bug which means focus never really gets to main content when using the skip link, and keyboard-navigation IOS users effectively cannot use the skip link.

It forces focus and a tabindex 0 value on the main content element. It also introduces an `<a>` as the target for main content, rather than `<main>`

## How to test

This is primarily only testable with the correct hardware: an IOS device & external keyboard.

1. Load a page.
2. Navigate to the skip link
3. Hit ENTER to activate it.
4. Verify that you have been brought to the main content area (i.e. past main nav/header)
5. Hit TAB again.
6. Verify that focus is now on the next available link or focusable element within main content.

**NB** 

- It is worth testing with a regular ol' browser via keyboard navigation and mouse click to make sure there is no regression.
- It can only really be validated with the correct hardware.

