### PR TITLE
feat: replaces standalone prev-next code with included version

### DIFF
--- a/templates/_components/prev-next.twig
+++ b/templates/_components/prev-next.twig
@@ -7,6 +7,8 @@
 
 {% set previous_icon = previous_icon|default('chevron-left') %}
 {% set next_icon = next_icon|default('chevron-right') %}
+{% set previous_aria_label = 'Previous'|t ~ (previous_title ? ': ' ~ previous_title : '') %}
+{% set next_aria_label = 'Next'|t ~ (next_title ? ': ' ~ next_title : '') %}
 
 {%
   set classes = [
@@ -23,7 +25,7 @@
   <ul class="lgd-prev-next__list">
     {% if previous_url %}
       <li class="lgd-prev-next__list-item lgd-prev-next__list-item--prev">
-        <a href="{{ previous_url }}#lgd-guides__title" class="lgd-prev-next__link lgd-prev-next__link--prev" aria-label="{{ 'Previous'|t }}: {{ previous_title }}">
+        <a href="{{ previous_url }}#lgd-guides__title" class="lgd-prev-next__link lgd-prev-next__link--prev" aria-label="{{ previous_aria_label }}">
           {% include "@localgov_base/includes/icons/icon.html.twig" with {
             icon_name: previous_icon,
             icon_classes: 'lgd-prev-next__icon lgd-prev-next__icon--prev',
@@ -42,7 +44,7 @@
     {% endif %}
     {% if next_url %}
       <li class="lgd-prev-next__list-item lgd-prev-next__list-item--next">
-        <a href="{{ next_url }}#lgd-guides__title" class="lgd-prev-next__link lgd-prev-next__link--next" aria-label="{{ 'Next'|t }}: {{ next_title }}">
+        <a href="{{ next_url }}#lgd-guides__title" class="lgd-prev-next__link lgd-prev-next__link--next" aria-label="{{ next_aria_label }}">
           <div class="lgd-prev-next__label">
             {{ 'Next'|t }}
           </div>

--- a/templates/views/views-view-list--localgov-step-by-step-navigation--prev-next.html.twig
+++ b/templates/views/views-view-list--localgov-step-by-step-navigation--prev-next.html.twig
@@ -42,44 +42,8 @@
 
 {% set previous_icon = 'chevron-left' %}
 {% set next_icon = 'chevron-right' %}
+{% set prev_next_type = 'step_by_step' %}
+{% set previous_url = has_prev_step ? path('entity.node.canonical', {'node': prev_step_nid }) : '' %}
+{% set next_url = has_next_step ? path('entity.node.canonical', {'node': next_step_nid }) : ''  %}
 
-<nav class="lgd-prev-next lgd-prev-next--step-by-step" aria-label={{ 'Step-by-step'|t }}>
-  {% set has_wrapper_attributes = attributes.toString() %}
-  {% if has_wrapper_attributes -%}
-    <div{{attributes}}>
-    {% endif %}
-    {% if title %}
-      <h3>{{ title }}</h3>
-    {% endif %}
-
-    <{{list.type}}{{list.attributes.addClass('lgd-prev-next__list') }}>
-      {% if has_prev_step %}
-        <li{{rows[prev_step_index].attributes.addClass('lgd-prev-next__list-item', 'lgd-prev-next__list-item--prev') }}>
-          <a href="{{ path('entity.node.canonical', {'node': prev_step_nid }) }}" class="lgd-prev-next__link lgd-prev-next__link--prev" aria-label="{{ 'Previous step'|t }}: {{ prev_step_title }}">
-            {% include "@localgov_base/includes/icons/icon.html.twig" with {
-                icon_name: previous_icon,
-                icon_classes: 'lgd-prev-next__icon lgd-prev-next__icon--prev',
-              }
-            %}
-            {{ prev_step_link_text }}</a>
-        </li>
-      {% endif %}
-
-      {% if has_next_step %}
-        <li{{rows[next_step_index].attributes.addClass('lgd-prev-next__list-item', 'lgd-prev-next__list-item--next') }}>
-          <a href="{{ path('entity.node.canonical', {'node': next_step_nid }) }}" class="lgd-prev-next__link lgd-prev-next__link--next" aria-label="{{ 'Next step'|t }}: {{ next_step_title }}">
-            {{ next_step_link_text }}
-            {% include "@localgov_base/includes/icons/icon.html.twig" with {
-                icon_name: next_icon,
-                icon_classes: 'lgd-prev-next__icon lgd-prev-next__icon--next',
-              }
-            %}
-          </a>
-        </li>
-      {% endif %}
-    </{{list.type}}>
-
-    {% if has_wrapper_attributes -%}
-    </div>
-  {% endif %}
-</nav>
+{% include "@localgov_base/_components/prev-next.twig" %}

--- a/templates/views/views-view-list--localgov-step-by-step-navigation--prev-next.html.twig
+++ b/templates/views/views-view-list--localgov-step-by-step-navigation--prev-next.html.twig
@@ -46,4 +46,4 @@
 {% set previous_url = has_prev_step ? path('entity.node.canonical', {'node': prev_step_nid }) : '' %}
 {% set next_url = has_next_step ? path('entity.node.canonical', {'node': next_step_nid }) : ''  %}
 
-{% include "@localgov_base/_components/prev-next.twig" %}
+{% include '@localgov_base/_components/prev-next.twig' %}


### PR DESCRIPTION
<!-- See https://docs.localgovdrupal.org/contributing/ for guidelines on contributing. -->

## What does this change?

The template `views-view-list--localgov-step-by-step-navigation--prev-next.html.twig` now uses the `_components/prev-next.twig` template, bringing it in line with guides and the localgov-blogs block template.

This has several side-effects, all of them small, one of them (I think) positive:

- the aria-label attribute is lost
- prev/next links now wrapped in div.lgd-prev_next__label
- labels now say "Previous" and "Next" instead of "Previous Step" and "Next Step"
- labels are now bold
- distance between links and footer now *more* consistent with other CTs

## How to test

Compare e.g. `/adult-health-and-social-care/step-by-step/request-support-adult-step-step/apply-financial-support` on an instance running this branch with [the current demo site](https://demo.localgovdrupal.org/adult-health-and-social-care/step-by-step/request-support-adult-step-step/apply-financial-support)

## How can we measure success?

This makes the markup and CSS more consistent with other identical UI components.

## Have we considered potential risks?

There are two questions about the effects:

1. is/was the aria-label on _this_ specific component deliberate and/or important?
2. is/was the difference in font-weight on _this_ specific component deliberate and/or important?

## Images

![image](https://github.com/user-attachments/assets/a1a99f55-6566-4d92-b92c-ddc2130cdaa2)

Left: existing implementation
Right: this PR's implementation

## Accessibility

-   [x] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [x] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [x] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [x] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)

My time on this provided by [Annertech](https://www.annertech.com/)