### PR TITLE
Add tabindex -1 to skip link target

### DIFF
--- a/templates/layout/page.html.twig
+++ b/templates/layout/page.html.twig
@@ -98,7 +98,7 @@
 
 {{ page.messages }}
 
-<main class="main" id="main-content"> {# The "skip to content" link jumps to here. #}
+<main class="main" id="main-content" tabindex="-1"> {# The "skip to content" link jumps to here. #}
 
   {% if has_content_top %}
     {{ page.content_top }}


### PR DESCRIPTION
##What does this change?

Adds `tabindex="-1"` to `<main>`.

This is for an IOS/keyboard navigation bug which means focus never really gets to main content when using the skip link, and keyboard-navigation IOS users effectively cannot use the skip link.

It allows focus the main content element.

## How to test

This is primarily only testable with the correct hardware: an IOS device & external keyboard.

1. Load a page.
2. Navigate to the skip link
3. Hit ENTER to activate it.
4. Verify that you have been brought to the main content area (i.e. past main nav/header)
5. Hit TAB again.
6. Verify that focus is now on the next available link or focusable element within main content.
