### PR TITLE
adds variables for heading colours for footer regions

### DIFF
--- a/css/base/variables.css
+++ b/css/base/variables.css
@@ -201,10 +201,13 @@ body {
   --section-spacing-vertical-pre-footer: var(--spacing-largest);
   --section-spacing-vertical-footer: var(--spacing);
   --section-spacing-vertical-post-footer: var(--spacing);
+  --color-pre-footer-heading: var(--color-white);
   --color-pre-footer-link: var(--color-white);
   --color-pre-footer-text: var(--color-white);
+  --color-footer-heading: var(--color-text);
   --color-footer-link: var(--color-link);
   --color-footer-text: var(--color-text);
+  --color-post-footer-heading: var(--color-text);
   --color-post-footer-link: var(--color-link);
   --color-post-footer-text: var(--color-text);
 

--- a/css/components/footer.css
+++ b/css/components/footer.css
@@ -34,3 +34,26 @@
 .lgd-footer__post-footer a {
   color: var(--color-post-footer-link);
 }
+
+/* Headings in footer regions */
+.lgd-footer__pre-footer h2,
+.lgd-footer__pre-footer h3,
+.lgd-footer__pre-footer h4,
+.lgd-footer__pre-footer h5,
+.lgd-footer__pre-footer h6 {
+  color: var(--color-pre-footer-heading);
+}
+.lgd-footer__footer h2,
+.lgd-footer__footer h3,
+.lgd-footer__footer h4,
+.lgd-footer__footer h5,
+.lgd-footer__footer h6 {
+  color: var(--color-footer-heading);
+}
+.lgd-footer__post-footer h2,
+.lgd-footer__post-footer h3,
+.lgd-footer__post-footer h4,
+.lgd-footer__post-footer h5,
+.lgd-footer__post-footer h6 {
+  color: var(--color-post-footer-heading);
+}


### PR DESCRIPTION
Closes #591 

## What does this change?

Adds variables for setting heading colours for footer region heading (h2, h3, h4, h5, h6).

## How to test

Set `localgov_base` as your active theme. Place blocks in the footer regions, set CSS variables for 

```
--color-pre-footer-heading
--color-footer-heading
--color-post-footer-heading
```

Check that the colour you set works.

---
Thanks to [Big Blue Door](https://www.bigbluedoor.net/) for sponsoring my time to work on this.