### PR TITLE
adds empty alt text for start icon button

### DIFF
--- a/css/base/ckeditor5.css
+++ b/css/base/ckeditor5.css
@@ -52,7 +52,7 @@
   position: relative;
   top: 7px;
   margin-left: 0.5rem;
-  content: "\203A";
+  content: "\203A" / "";
   font-size: 2.875rem;
 }
 

--- a/css/components/header.css
+++ b/css/components/header.css
@@ -104,7 +104,7 @@
 .lgd-header__toggle-icon::after {
   display: inline-block;
   margin-left: var(--spacing-smaller);
-  content: "\203A";
+  content: "\203A" / "";
   transition: var(--transition-time);
   transform: rotate(90deg);
   font-size: var(--font-size-larger);

--- a/css/components/wysiwyg-styles.css
+++ b/css/components/wysiwyg-styles.css
@@ -53,7 +53,7 @@
   position: relative;
   top: var(--btn-start-icon-top);
   margin-left: 0.5rem;
-  content: var(--btn-start-icon);
+  content: var(--btn-start-icon) / "";
   font-size: var(--btn-start-icon-size);
   line-height: 0;
 }


### PR DESCRIPTION
Closes #427 

## What does this change?

Adds empty alt text after the start button icon so screenreaders will treat it as purely decorative and not read it out.

## How to test

Add a start button into the body of a service page. Make sure the icon `>` is still there, but that it is not read out by any screenreaders.

## Accessibility

-   [ x] [Tested with screen reader - VoiceOver Mac](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [x ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)

---
Thanks to [Big Blue Door](https://www.bigbluedoor.net/) for sponsoring my time to work on this.
