### PR TITLE
312 add back to top button

### DIFF
--- a/css/components/back-to-top.css
+++ b/css/components/back-to-top.css
@@ -1,0 +1,6 @@
+.button.back-to-top:not([hidden]) {
+  bottom: 1em;
+  display: inline-block;
+  position: fixed;
+  right: 1em;
+}

--- a/css/components/back-to-top.css
+++ b/css/components/back-to-top.css
@@ -1,6 +1,35 @@
-.button.back-to-top:not([hidden]) {
-  bottom: 1em;
-  display: inline-block;
+.back-to-top {
+  background: var(--button-link-bg-color);
+  border: 3px solid var(--color-white);
+  bottom: 2em;
+  color: var(--button-link-color);
+  display: flex;
+  font-weight: bold;
+  gap: var(--spacing-small);
+  padding: var(--button-link-padding);
   position: fixed;
-  right: 1em;
+  right: 2em;
+  text-decoration: none;
+  transition: var(--transition-time);
+  opacity: 1;
+}
+
+.back-to-top[hidden] {
+  opacity: 0;
+}
+
+.back-to-top:hover,
+.back-to-top:focus {
+  text-decoration: underline;
+}
+
+.back-to-top__icon svg path {
+  fill: currentcolor;
+}
+
+@media screen and (min-width: 48rem) {
+  .back-to-top {
+    bottom: 5em;
+    right: 5em;
+  }
 }

--- a/css/components/back-to-top.css
+++ b/css/components/back-to-top.css
@@ -27,6 +27,12 @@
   fill: currentcolor;
 }
 
+.back-to-top-target {
+  max-height: 1px;
+  max-width: 1px;
+  overflow: hidden;
+}
+
 @media screen and (min-width: 48rem) {
   .back-to-top {
     bottom: 5em;

--- a/js/back-to-top.js
+++ b/js/back-to-top.js
@@ -1,0 +1,64 @@
+/**
+ * @file Drupal behavior for 'back to top' link.
+ */
+
+(function (Drupal) {
+  Drupal.behaviors.localgovBackToTop = {
+    attach(context) {
+      /**
+       * Callback for intersection observer.
+       *
+       * Sets back to top link's hidden attribute to "false" if the intersection
+       * target is either:
+       *
+       * - intersecting the viewport, OR
+       * - has been scrolled UP out of the viewport
+       *
+       * @param {IntersectionObserverEntry[]} entries
+       *   The qualifying entries to be checked for intersection with, or
+       *   past the top of the viewport. In practices, there's only one of
+       *   these since we've only targeted on element.
+       */
+      function observerCallback(entries) {
+        entries.forEach((entry) => {
+          backToTop.hidden = !(
+            entry.isIntersecting ||
+            (!entry.isIntersecting && entry.boundingClientRect.top <= 0)
+          );
+        });
+      }
+
+      const [backToTop] = once("back-to-top", ".back-to-top", context);
+      const [backToTopTarget] = once(
+        "back-to-top-target",
+        ".back-to-top-target",
+        context,
+      );
+      const minContentViewportRatio = parseFloat(
+        backToTop?.dataset?.minContentViewportRatio ?? 1.5,
+        10,
+      );
+      const viewportHeight = window.innerHeight;
+      const documentHeight = document.documentElement.offsetHeight;
+      let intersectionObserver;
+
+      if (
+        !backToTop ||
+        !backToTopTarget ||
+        documentHeight / viewportHeight < minContentViewportRatio
+      ) {
+        return;
+      }
+
+      // Create an element absolutely positioned at our threshold.
+      backToTopTarget.style.position = "absolute";
+      backToTopTarget.style.top = `${viewportHeight * minContentViewportRatio}px`;
+
+      // Create an IntersectionObserver.
+      intersectionObserver = new IntersectionObserver(observerCallback, {
+        rootMargin: "16px",
+      });
+      intersectionObserver.observe(backToTopTarget);
+    },
+  };
+})(Drupal);

--- a/js/back-to-top.js
+++ b/js/back-to-top.js
@@ -17,7 +17,7 @@
        * @param {IntersectionObserverEntry[]} entries
        *   The qualifying entries to be checked for intersection with, or
        *   past the top of the viewport. In practices, there's only one of
-       *   these since we've only targeted on element.
+       *   these since we've only targeted one element.
        */
       function observerCallback(entries) {
         entries.forEach((entry) => {

--- a/js/back-to-top.js
+++ b/js/back-to-top.js
@@ -53,6 +53,7 @@
       // Create an element absolutely positioned at our threshold.
       backToTopTarget.style.position = "absolute";
       backToTopTarget.style.top = `${viewportHeight * minContentViewportRatio}px`;
+      backToTop.addEventListener("click", (event) => event.target.hidden = true);
 
       // Create an IntersectionObserver.
       intersectionObserver = new IntersectionObserver(observerCallback, {

--- a/js/back-to-top.js
+++ b/js/back-to-top.js
@@ -21,10 +21,10 @@
        */
       function observerCallback(entries) {
         entries.forEach((entry) => {
-          backToTop.hidden = !(
+          backToTop.hidden = (
             entry.isIntersecting ||
             (!entry.isIntersecting && entry.boundingClientRect.top <= 0)
-          );
+          ) ? false : "until-hidden";
         });
       }
 
@@ -53,7 +53,7 @@
       // Create an element absolutely positioned at our threshold.
       backToTopTarget.style.position = "absolute";
       backToTopTarget.style.top = `${viewportHeight * minContentViewportRatio}px`;
-      backToTop.addEventListener("click", (event) => event.target.hidden = true);
+      backToTop.addEventListener("click", (event) => event.target.hidden = "until-found");
 
       // Create an IntersectionObserver.
       intersectionObserver = new IntersectionObserver(observerCallback, {

--- a/js/back-to-top.js
+++ b/js/back-to-top.js
@@ -8,7 +8,7 @@
       /**
        * Callback for intersection observer.
        *
-       * Sets back to top link's hidden attribute to "false" if the intersection
+       * Sets back to top link's hidden attribute to 'false' if the intersection
        * target is either:
        *
        * - intersecting the viewport, OR
@@ -24,14 +24,14 @@
           backToTop.hidden = (
             entry.isIntersecting ||
             (!entry.isIntersecting && entry.boundingClientRect.top <= 0)
-          ) ? false : "until-hidden";
+          ) ? false : 'until-hidden';
         });
       }
 
-      const [backToTop] = once("back-to-top", ".back-to-top", context);
+      const [backToTop] = once('back-to-top', '.back-to-top', context);
       const [backToTopTarget] = once(
-        "back-to-top-target",
-        ".back-to-top-target",
+        'back-to-top-target',
+        '.back-to-top-target',
         context,
       );
       const minContentViewportRatio = parseFloat(
@@ -51,13 +51,13 @@
       }
 
       // Create an element absolutely positioned at our threshold.
-      backToTopTarget.style.position = "absolute";
+      backToTopTarget.style.position = 'absolute';
       backToTopTarget.style.top = `${viewportHeight * minContentViewportRatio}px`;
-      backToTop.addEventListener("click", (event) => event.target.hidden = "until-found");
+      backToTop.addEventListener('click', (event) => event.target.hidden = 'until-found');
 
       // Create an IntersectionObserver.
       intersectionObserver = new IntersectionObserver(observerCallback, {
-        rootMargin: "16px",
+        rootMargin: '16px',
       });
       intersectionObserver.observe(backToTopTarget);
     },

--- a/localgov_base.libraries.yml
+++ b/localgov_base.libraries.yml
@@ -317,3 +317,13 @@ add-to-calendar:
   dependencies:
     - core/drupal
     - core/once
+
+back-to-top:
+  css:
+    theme:
+      css/components/back-to-top.css: {}
+  js:
+    js/back-to-top.js: {}
+  dependencies:
+    - core/drupal
+    - core/once

--- a/localgov_base.theme
+++ b/localgov_base.theme
@@ -46,6 +46,13 @@ function localgov_base_form_system_theme_settings_alter(&$form, FormStateInterfa
     '#default_value' => theme_get_setting('localgov_base_add_draft_note_to_unpublished_content'),
     '#description'   => t('This adds the word "Draft" to the title of any unpublished content. This is useful if you have removed the pink background from unpublished content.'),
   ];
+
+  $form['localgov_base_show_back_to_top_link'] = [
+    '#type'          => 'checkbox',
+    '#title'         => t('Display a "Back to Top" link on long pages.'),
+    '#default_value' => theme_get_setting('localgov_base_show_back_to_top_link'),
+    '#description'   => t('This adds a link to the beginning of the page content (<code>#main-content</code>).'),
+  ];
 }
 
 /**
@@ -93,6 +100,11 @@ function localgov_base_preprocess_page(&$variables) {
   // we will add the 'unpublished' library to our page.
   if (theme_get_setting('localgov_base_add_unpublished_background_colour') === TRUE) {
     $variables['#attached']['library'][] = 'localgov_base/unpublished-bg';
+  }
+
+  // Render the Back to Top link or not according to the theme setting.
+  if (theme_get_setting('localgov_base_show_back_to_top_link')) {
+    $variables['back_to_top'] = TRUE;
   }
 }
 

--- a/templates/_components/back-to-top.twig
+++ b/templates/_components/back-to-top.twig
@@ -1,15 +1,51 @@
+{#
+/**
+ * Template for "back-to-top" link.
+ *
+ * The template includes two HTML elements:
+ *
+ * 1. the "back-to-top" link itself
+ * 2. a "back-to-top-target" span
+ *
+ * The javascript from localgov_base/back-to-top interacts with this template
+ * as follows:
+ *
+ * - absolutely positions the target span
+ * - creates an intersection observer to observe it
+ * - un-hides the link when the target enters the viewport
+ * - re-hides the link when the target exits the *bottom* of the viewport
+ * - re-hides the link when it's clicked [1]
+ *
+ * The template includes no wrapping <div> element, and the css explicitly sets
+ * the maximum size of the target to 1px x 1px to minimize the chances of an
+ * element from the template blocking content.
+ *
+ * [1] on small enough screens--especially with several visible banners--the
+ * link will *already* be visible when #main-content is reached, so re-hiding
+ * the link fails in that circumstance.
+ */
+#}
+
+{% set default_ratio = 1.5 %}
+{% set btt_icon_name = 'arrow-up' %}
+{% set btt_icon_class = 'back-to-top__icon' %}
+{% set btt_link_text = 'Back to top' %}
+{% set btt_link_class = 'back-to-top' %}
+{% set btt_target_class = 'back-to-top-target' %}
+
 {{ attach_library('localgov_base/back-to-top') }}
+
 <a
-  class="back-to-top"
-  data-min-content-viewport-ratio="1.5"
+  class="{{ btt_link_class }}"
+  data-min-content-viewport-ratio="{{ default_ratio }}"
   href="#main-content"
   hidden
 >
   {% include "@localgov_base/includes/icons/icon.html.twig" with {
-    icon_name: 'arrow-up',
+    icon_name: btt_icon_name,
     icon_wrapper_element: 'span',
-    icon_classes: 'back-to-top__icon',
+    icon_classes: btt_icon_class,
   } %}
-  {{ 'Back to top'|t }}
+  {{ btt_link_text|t }}
 </a>
-<span class="back-to-top-target" aria-hidden></span>
+<span class="{{ btt_target_class }}" aria-hidden></span>

--- a/templates/_components/back-to-top.twig
+++ b/templates/_components/back-to-top.twig
@@ -1,8 +1,15 @@
 {{ attach_library('localgov_base/back-to-top') }}
 <a
-  class="button back-to-top"
+  class="back-to-top"
   data-min-content-viewport-ratio="1.5"
   href="#main-content"
   hidden
->{{ 'Back to top'|t }}</a>
+>
+  {% include "@localgov_base/includes/icons/icon.html.twig" with {
+    icon_name: 'arrow-up',
+    icon_wrapper_element: 'span',
+    icon_classes: 'back-to-top__icon',
+  } %}
+  {{ 'Back to top'|t }}
+</a>
 <span class="back-to-top-target" aria-hidden></span>

--- a/templates/_components/back-to-top.twig
+++ b/templates/_components/back-to-top.twig
@@ -1,0 +1,8 @@
+{{ attach_library('localgov_base/back-to-top') }}
+<a
+  class="button back-to-top"
+  data-min-content-viewport-ratio="1.5"
+  href="#main-content"
+  hidden
+>{{ 'Back to top'|t }}</a>
+<span class="back-to-top-target" aria-hidden></span>

--- a/templates/_components/back-to-top.twig
+++ b/templates/_components/back-to-top.twig
@@ -39,7 +39,7 @@
   class="{{ btt_link_class }}"
   data-min-content-viewport-ratio="{{ default_ratio }}"
   href="#main-content"
-  hidden
+  hidden="until-found"
 >
   {% include "@localgov_base/includes/icons/icon.html.twig" with {
     icon_name: btt_icon_name,

--- a/templates/layout/page.html.twig
+++ b/templates/layout/page.html.twig
@@ -171,6 +171,15 @@
   {% endif %}
 </main>
 
+{% if back_to_top %}
+  {#
+    Position the link just after <main> at the end so that it's in about the
+    right place, *and* to try to minimize the chances of being rendered inside
+    a positioned element.
+  #}
+  {% include "@localgov_base/_components/back-to-top.twig" %}
+{% endif %}
+
 {# Begin Footer Regions #}
 {% block footer_sections %}
   {% if footer_regions %}


### PR DESCRIPTION
## What does this change?

<!-- A pull request should have enough detail to be understandable far in the
future. e.g what is the problem/why is the change needed, how does it solve it
and any questions or points of discussion. Prefer copying information from a
Trello card (for example) over linking to it; the card may not always exist and
reviewers may not have access to the board. -->

It adds a "Back to Top" link per #312 just after the end of `<main>`. I've set up variables in the component, and placed the twig template in `templates/_components`, anticipating that this might be a good candidate for SDC conversion.

From the Twig template's comments, the component works like this:

> The template includes two HTML elements:
> 
> 1. the "back-to-top" link itself
> 2. a "back-to-top-target" span
> 
> The javascript from localgov_base/back-to-top interacts with this template as follows:
> 
>  - absolutely positions the target span
>  - creates an intersection observer to observe it
>  - un-hides the link when the target enters the viewport
>  - re-hides the link when the target exits the *bottom* of the viewport
>  - re-hides the link when it's clicked [1]
> 
>  The template includes no wrapping <div> element, and the css explicitly sets the maximum size of the target to 1px x 1px to minimize the chances of an element from the template blocking content.
> 
> [1] on small enough screens--especially with several visible banners--the link will *already* be visible when #main-content is reached, so re-hiding the link fails in that circumstance.

## How to test

<!-- Provide instructions to help others verify the change. This could take the
form of "On main, do X and witness Y. On this branch, do X and witness Z. " -->

On any page that's at least 1.5x as long as the browser viewport ([the demo homepage works with a window > 1300px high):

- scroll normally, watching the bottom right corner of the viewport
- when the link appears, click it

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be
simplified? What can be used to prove this? A filtered view of logs or
analytics, etc? -->
- [ ] the link appears in the expected circumstances
- [ ] only the exact bounds of the link block other content
- [ ] clicking the link returns to `#main-content`
- [ ] the link re-hides on click (note: in circumstances where the link appears before/as soon as `#main-content` is visible, the link won't re-hide when clicked)
- [ ] the link re-hides when scrolled off the _bottom_ of the viewport subject to the same note as for click, above.

## Have we considered potential risks?

The main risks I can see are:

1. accidentally blocking content with the "target" span
2. confusion re: the new UI component

I think both of these are addressed by in CSS: (1) by explicitly restricting the size and location (1px x 1px, at extreme left of page), and (2) by use of an icon and LGD-matching link/button styles.

## Images

![image](https://github.com/user-attachments/assets/57ebb93d-b404-4b1a-8802-8c66f826f8c3)

## Accessibility

The link uses `hidden="until-found"` for its hidden state. This means in supporting browsers (Chrome-based, at the moment), the link doesn't rely on javascript to be discovered (meaning keyboard navigation will reveal it even absent js).

-   [x] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [x] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [x] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [x] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)