### PR TITLE
564 use prev next twig for publications prev next

### DIFF
--- a/templates/block/guides-prev-next-block.html.twig
+++ b/templates/block/guides-prev-next-block.html.twig
@@ -1,2 +1,2 @@
 {% set prev_next_type = 'guides' %}
-{% include "@localgov_base/_components/prev-next.twig" %}
+{% include '@localgov_base/_components/prev-next.twig' %}

--- a/templates/navigation/book-navigation--publication.html.twig
+++ b/templates/navigation/book-navigation--publication.html.twig
@@ -1,0 +1,41 @@
+{#
+/**
+ * @file
+ * Default theme implementation to navigate books.
+ *
+ * Presented under nodes that are a part of book outlines.
+ *
+ * Available variables:
+ * - tree: The immediate children of the current node rendered as an unordered
+ *   list.
+ * - current_depth: Depth of the current node within the book outline. Provided
+ *   for context.
+ * - prev_url: URL to the previous node.
+ * - prev_title: Title of the previous node.
+ * - parent_url: URL to the parent node.
+ * - parent_title: Title of the parent node. Not printed by default. Provided
+ *   as an option.
+ * - next_url: URL to the next node.
+ * - next_title: Title of the next node.
+ * - has_links: Flags TRUE whenever the previous, parent or next data has a
+ *   value.
+ * - book_id: The book ID of the current outline being viewed. Same as the node
+ *   ID containing the entire outline. Provided for context.
+ * - book_url: The book/node URL of the current outline being viewed. Provided
+ *   as an option. Not used by default.
+ * - book_title: The book/node title of the current outline being viewed.
+ *
+ * @see template_preprocess_book_navigation()
+ *
+ * @ingroup themeable
+ */
+#}
+
+{% if has_links %}
+  {# This uses previous_* vars, prev-next uses prev_*, so we translate. #}
+  {% set previous_url = prev_url %}
+  {% set previous_title = prev_title %}
+  {% set show_title = 1 %}
+  {% set prev_next_type = 'publications' %}
+  {% include '@localgov_base/_components/prev-next.twig' %}
+{% endif %}


### PR DESCRIPTION
## What does this change?

Replaces `localgov_publication` specific book-navigation template with theme implementation using `_components/prev-next.twig`.

## How to test

View e.g. [Petitions Scheme - Publications Demo Content](publications/publications-cover-page-demo-content/petitions-scheme-publications-demo-content) with this branch checked out.

## How can we measure success?

- [ ] the `<nav>` element now uses the `localgov_base` template
- [ ] the _markup_ is identical to other implementation
- [ ] the visual change to Publications nav is acceptable

## Have we considered potential risks?

- As in #588, this eliminates an `aria-*` attribute on the `<nav>` element, but preserves `aria-label` attributes on the Prev/Next links.

## Images

![image](https://github.com/user-attachments/assets/f2406c32-1e43-4f74-87df-ff08d0c5e910)

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [x] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [x] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [x] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [x] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)