### PR TITLE
597 Don't render regions up-front to see if they are empty

### DIFF
--- a/localgov_base.theme
+++ b/localgov_base.theme
@@ -8,6 +8,7 @@
 use Drupal\Component\Utility\Crypt;
 use Drupal\Component\Utility\DeprecationHelper;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Render\Element;
 use Drupal\views\ViewExecutable;
 
 /**
@@ -76,18 +77,7 @@ function localgov_base_preprocess_page(&$variables) {
     if (in_array($region, $excluded_regions, TRUE)) {
       continue;
     }
-    $copy = $variables['page'][$region];
-
-    /** @var \Drupal\Core\Render\RendererInterface $renderer */
-    $renderer = \Drupal::service('renderer');
-    $rendered = DeprecationHelper::backwardsCompatibleCall(
-      currentVersion: \Drupal::VERSION,
-      deprecatedVersion: '10.3',
-      currentCallable: fn() => $renderer->renderInIsolation($copy),
-      deprecatedCallable: fn() => $renderer->renderPlain($copy),
-    );
-
-    $variables['has_' . $region] = strlen(trim(strip_tags($rendered, '<drupal-render-placeholder><embed><hr><iframe><img><input><link><object><script><source><style><video>'))) > 0;
+    $variables['has_' . $region] = !empty(Element::children($variables['page'][$region]));
   }
   $variables['has_sidebars'] = $variables['has_sidebar_first'] || $variables['has_sidebar_second'];
 


### PR DESCRIPTION
<!-- See https://docs.localgovdrupal.org/contributing/ for guidelines on contributing. -->

## What does this change?

Does not render regions in `localgov_base_preprocess_page()` when determining things like `has_sidebars`.

A region is now considered non-empty if it one or more blocks are placed within it (and those blocks are configured to be visible).
We do not consider what those blocks will actually output (if anything).
If a block is placed but produces no output, its region is still considered to be non-empty.

This is closer to Drupal's core behaviour and is necessary for placeholdering and BigPipe to work properly.

See https://github.com/localgovdrupal/localgov_base/issues/597 for discussion

## How to test

1. Add a block that produces no content. (This can be a custom block plugin, a view, anything)
2. Place that in a sidebar. Make sure it is the only thing in the sidebar.
3. The page should render with a sidebar.

## How can we measure success?

An otherwise cacheable page with an uncacheable block in a sidebar will now be cacheable.

## Have we considered potential risks?

Sites which rely on this to hide sidebars when blocks do not produce content may find that those sidebars now appear.

That can be mitigated against, with:
- visibility conditions on the block configuration page
- using CSS `:has` to detect emptiness on the client side
- a [contrib module](https://www.drupal.org/sandbox/ingaro/3471436) to force blocks to render ahead of time 

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)