### PR TITLE
fix: set color on service status heading

### DIFF
--- a/css/components/service-statuses.css
+++ b/css/components/service-statuses.css
@@ -18,6 +18,7 @@
 
 .service-statuses__label {
   margin-bottom: 0;
+  color: var(--service-statuses-container-text-color);
 }
 
 .service-statuses__link {


### PR DESCRIPTION
<!-- See https://docs.localgovdrupal.org/contributing/ for guidelines on contributing. -->

## What does this change?

Fixes the heading colour of service status (e.g. https://demo.localgovdrupal.org/births-deaths-marriages-and-citizenship).

Also fixes #606.

**Before**
![image](https://github.com/user-attachments/assets/9f87b527-320a-49f1-b48a-c3660c4c3e75)

**After**
![image](https://github.com/user-attachments/assets/f2944852-f06b-427e-aa1e-99f60dfca7cf)
