### PR TITLE
feat: add last updated date to service pages

### DIFF
--- a/templates/content/node--full.html.twig
+++ b/templates/content/node--full.html.twig
@@ -146,6 +146,10 @@
       <div{{ content_attributes.addClass(content_type|clean_class ~ '__content', 'node__content') }}>
         {{ content|without('localgov_subsites_content') }}
       </div>
+
+      {% if content_type == 'localgov_services_page' %}
+        <span>{% trans %}Last updated:{% endtrans %}</span> {{ node.changed.value|format_date('custom', 'j F Y') }}
+      {% endif %}
   </div>
 
   {% if node.localgov_subsites_content.value or content.localgov_subsites_content['#type'] == 'layout_paragraphs_builder' %}


### PR DESCRIPTION
<!-- See https://docs.localgovdrupal.org/contributing/ for guidelines on contributing. -->

I've added this to some projects in the past, so I've rolled up this small change to a PR. This is probably one for further discussion as to whether this should be default. However if there is a case to not want this the template can be overridden.

## What does this change?

For service pages only this adds the date the page was last changed/updated

Example:
![image](https://github.com/user-attachments/assets/86e1e034-36d9-4a8d-9dfb-7eee099fcb17)
