### PR TITLE
hides guides/steps navigation in print mode

### DIFF
--- a/css/print/print.css
+++ b/css/print/print.css
@@ -3,7 +3,10 @@
 .lgd-region__inner--header > *:not(.block-system-branding-block),
 .sidebar,
 .lgd-prev-next,
-.newsroom__sidebar {
+.newsroom__sidebar,
+.block-localgov-guides-contents,
+.block-views-blocklocalgov-step-by-step-navigation-steps-for-overview,
+.block-views-blocklocalgov-step-by-step-navigation-steps {
   display: none;
 }
 


### PR DESCRIPTION
Closes #614 

## What does this change?

Removes guides and step-by-step navigation blocks when printing these pages.

---
Thanks to [Big Blue Door](https://www.bigbluedoor.net/) for sponsoring my time to work on this.