### PR TITLE
adds CSS for blockquotes created via WYSIWYG

### DIFF
--- a/css/base/base.css
+++ b/css/base/base.css
@@ -162,6 +162,13 @@ ol ul {
   margin-bottom: 0;
 }
 
+blockquote:not(.pull-out-quote__content) {
+  padding-inline-start: var(--quote-padding);
+  padding-left: var(--quote-padding-left);
+  border-inline-start: var(--quote-border);
+  border-color: var(--color-accent);
+}
+
 sub,
 sup {
   position: relative;

--- a/css/components/quote.css
+++ b/css/components/quote.css
@@ -5,7 +5,7 @@
   padding: var(--quote-padding);
   padding-left: var(--quote-padding-left);
   border-color: var(--quote-border-color);
-  border-left: var(--quote-border);
+  border-inline-start: var(--quote-border);
   background-color: var(--quote-bg-color);
 }
 


### PR DESCRIPTION
Closes #611 

## What does this change?

Adds CSS to give the `blockquote` element some styling, so that blockquotes created via WYSIWYG have a visual affordance.

## How to test

Create a blockquote via WYSIWYG and make sure it has a border beside it.

## Have we considered potential risks?

We already have CSS for existing blockquotes created via the "Pull Out Quote" component. This new CSS re-uses that for general blockquotes and uses a `:not` selector so existing pull-out-quotes are not affected.

---
Thanks to [Big Blue Door](https://www.bigbluedoor.net/) for sponsoring my time to work on this.