### PR TITLE
ensures quick fact content is inside a <p> tag

### DIFF
--- a/templates/paragraphs/paragraph--localgov-fact-box.html.twig
+++ b/templates/paragraphs/paragraph--localgov-fact-box.html.twig
@@ -66,14 +66,14 @@
         {{ paragraph.localgov_above_text.value }}
       </p>
     {% endif %}
-    
+
     <div class="fact-box__fact">
       <p>
-        {{ content.localgov_fact }}
+        {{ paragraph.localgov_fact.value }}
       </p>
       {{ content|without('localgov_above_text', 'localgov_fact', 'localgov_below_text', 'localgov_background') }}
     </div>
-    
+
     {% if paragraph.localgov_below_text.value %}
       <p class="fact-box__closing">
         {{ paragraph.localgov_below_text.value }}


### PR DESCRIPTION
Closes #607 

## What does this change?

Our template "nearly" puts the text of a quick fact into `p` tags, but since we render `{{ content.localgov_fact }}` the render array produces a `div` which in turn means we render an empty `p` tag followed by the content.

This PR sorts that so that we render `{{ content.localgov_fact.value }}` instead so it goes inside the `p` tag.

## How to test

Visit https://localgov.ddev.site/adult-health-and-social-care/another-service-landing-page/service-page and check that the content in the fact box is inside a `p` tag.

## Accessibility
The original issue says "Key information is styled in a way that suggests importance but does not use appropriate semantic elements to convey its meaning.".

However, I am not sure what semantic elements to use except `p` for these elements. It's not clear _in all circumstances_ (so we could make this generic) if any of the constituent parts should be headings or something else.

---
Thanks to [Big Blue Door](https://www.bigbluedoor.net/) for sponsoring my time to work on this.