### PR TITLE
adds more space for clickable area for pager items

### DIFF
--- a/css/components/pager.css
+++ b/css/components/pager.css
@@ -14,3 +14,7 @@
 .pager__item::marker {
   color: transparent;
 }
+
+.pager__item > a {
+  padding-inline: var(--spacing-smaller);
+}


### PR DESCRIPTION
Closes #618 

## What does this change?

Adds a small bit of padding to links in pagers so they are easier to click on.

## How to test

Go to a page with a pager, you should be able to click the links in the pager and a small bit of space each side of the link.

---
Thanks to [Big Blue Door](https://www.bigbluedoor.net/) for sponsoring my time to work on this.