### PR TITLE
Fix config schema error #629

### DIFF
--- a/config/schema/localgov_base.schema.yml
+++ b/config/schema/localgov_base.schema.yml
@@ -15,11 +15,8 @@ localgov_base.settings:
       type: boolean
       label: 'Add "[Draft]" to title of unpublished content.'
     localgov_base_header_behaviour:
-      type: enum
+      type: string
       label: 'Header behaviour'
       description: 'Choose whether the header should be sticky or not.'
-      default: 'default'
-      options:
-        'default': 'Default - scrolls away with the page'
-        'sticky': 'Sticky - remains at the top of the page'
-        'appears_on_scroll': 'Scroll - appears when scrolling up'
+      constraints:
+        Regex: '^(default|sticky|appears_on_scroll)$'


### PR DESCRIPTION
Fixes #629. Should allow the 1.7.0 release #622 to progress.

## What does this change?

There isn't an `enum` schema type so using `string` instead with a constraint.

## How to test

Checkout this branch and the `feature/740/enable-localgov_base-helper-module` branch from localgov, as used here: https://github.com/localgovdrupal/localgov/pull/741. Then run the tests in this module.

Not using the profile branch results in test failing with message: Unable to install theme: 'localgov_base' due to unmet module dependencies: 'localgov_base_helper'.
