### PR TITLE
Fix: Empty facets form controls

### DIFF
--- a/css/components/form-items.css
+++ b/css/components/form-items.css
@@ -376,7 +376,7 @@ input[type="file"]:hover,
   margin-block-start: var(--spacing-largest);
 }
 
-.facets-form .form-actions {
+.facets-form .form-actions:not(.hidden) {
   display: flex;
   flex-wrap: wrap;
   gap: var(--spacing);


### PR DESCRIPTION
Sorry Mark, this morning I forgot to test the scenario where no facets apply which is now causing troubles :(  Proposing a fix to address this.

## What does this change?
Empty facets forms should not display their control buttons.

## How to test
- Install the facets_form module.
- Edit the localgov_directories_facets facet from /admin/config/search/facets/localgov_directories_facets/edit
 - Select the `Checkboxes (inside form)` widget near the top of the page and save settings.
 - From the block layout page at /admin/structure/block, place the `Facet form: View Directory channel, display Embed block` in a sidebar.
 - [Optional] Disable the existing facet block from the block layout page at /admin/structure/block.
 - Open an existing directory channel page and search for an improbably string such as "foobarbazqux".
 - The "Search" and "Clear filter" control buttons of the Facets form will appear under the search form even though no facet items are applicable.

## How can we measure success?
When searching for an improbable string, no part of the facets form should be visible.

## Have we considered potential risks?
Can't think of any.

## Images
![image](https://github.com/user-attachments/assets/e7596109-fdd3-4a62-a273-7193e9d6547f)