### PR TITLE
Release 1.7.1

### DIFF
--- a/css/components/form-items.css
+++ b/css/components/form-items.css
@@ -376,7 +376,7 @@ input[type="file"]:hover,
   margin-block-start: var(--spacing-largest);
 }
 
-.facets-form .form-actions {
+.facets-form .form-actions:not(.hidden) {
   display: flex;
   flex-wrap: wrap;
   gap: var(--spacing);


### PR DESCRIPTION
Bug fix release.  Fixed the scenario where a [facets_form](https://www.drupal.org/project/facets_form) form block has no facet items within but displays unneeded `Search` and `Reset` buttons nonetheless.