### PR TITLE
Removed URL fragment from template and moved it to a guides specific preprocess, so it only appears on guides.

### DIFF
--- a/localgov_base.theme
+++ b/localgov_base.theme
@@ -8,6 +8,7 @@
 use Drupal\Component\Utility\Crypt;
 use Drupal\Component\Utility\DeprecationHelper;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Url;
 use Drupal\views\ViewExecutable;
 
 /**
@@ -247,4 +248,16 @@ function localgov_base_preprocess_container(&$variables) {
  */
 function localgov_base_form_preview_link_entity_form_alter(&$form, $form_state, $form_id) {
   $form['#attached']['library'][''] = 'localgov_base/preview-link';
+}
+
+/**
+ * Implements hook_preprocess_guides_prev_next_block().
+ */
+function localgov_base_preprocess_guides_prev_next_block(&$variables) {
+  if ($variables['previous_url'] instanceof Url) {
+    $variables['previous_url']->setOption('fragment', 'lgd-guides__title');
+  }
+  if ($variables['next_url'] instanceof Url) {
+    $variables['next_url']->setOption('fragment', 'lgd-guides__title');
+  }
 }

--- a/templates/_components/prev-next.twig
+++ b/templates/_components/prev-next.twig
@@ -25,7 +25,7 @@
   <ul class="lgd-prev-next__list">
     {% if previous_url %}
       <li class="lgd-prev-next__list-item lgd-prev-next__list-item--prev">
-        <a href="{{ previous_url }}#lgd-guides__title" class="lgd-prev-next__link lgd-prev-next__link--prev" aria-label="{{ previous_aria_label }}">
+        <a href="{{ previous_url }}" class="lgd-prev-next__link lgd-prev-next__link--prev" aria-label="{{ previous_aria_label }}">
           {% include "@localgov_base/includes/icons/icon.html.twig" with {
             icon_name: previous_icon,
             icon_classes: 'lgd-prev-next__icon lgd-prev-next__icon--prev',
@@ -44,7 +44,7 @@
     {% endif %}
     {% if next_url %}
       <li class="lgd-prev-next__list-item lgd-prev-next__list-item--next">
-        <a href="{{ next_url }}#lgd-guides__title" class="lgd-prev-next__link lgd-prev-next__link--next" aria-label="{{ next_aria_label }}">
+        <a href="{{ next_url }}" class="lgd-prev-next__link lgd-prev-next__link--next" aria-label="{{ next_aria_label }}">
           <div class="lgd-prev-next__label">
             {{ 'Next'|t }}
           </div>


### PR DESCRIPTION
Fix for #640 