### PR TITLE
Converts CSS to logical properties

### DIFF
--- a/css/base/base.css
+++ b/css/base/base.css
@@ -13,7 +13,7 @@ html {
 *::before,
 *::after {
   box-sizing: border-box;
-  margin-top: 0; /* Removing top margin, for better vertical rhythm layout */
+  margin-block-start: 0; /* Removing top margin, for better vertical rhythm layout */
 }
 
 dialog {
@@ -43,7 +43,7 @@ body {
 
 main {
   /* To give us a sticky footer. */
-  margin-bottom: auto;
+  margin-block-end: auto;
 }
 
 a {
@@ -78,7 +78,7 @@ h5,
 h6,
 .h6,
 .heading {
-  margin-bottom: var(--vertical-rhythm-spacing);
+  margin-block-end: var(--vertical-rhythm-spacing);
   font-family: var(--font-secondary);
 }
 
@@ -152,19 +152,19 @@ ol,
 pre,
 table,
 blockquote {
-  margin-bottom: var(--vertical-rhythm-spacing);
+  margin-block-end: var(--vertical-rhythm-spacing);
 }
 
 ul ul,
 ol ol,
 ul ol,
 ol ul {
-  margin-bottom: 0;
+  margin-block-end: 0;
 }
 
 blockquote:not(.pull-out-quote__content) {
   padding-inline-start: var(--quote-padding);
-  padding-left: var(--quote-padding-left);
+  padding-inline-start: var(--quote-padding-inline-start);
   border-inline-start: var(--quote-border);
   border-color: var(--color-accent);
 }

--- a/css/base/ckeditor.css
+++ b/css/base/ckeditor.css
@@ -50,7 +50,7 @@
 
 .btn.btn-start::after {
   top: -2px;
-  margin-left: 0.5rem;
+  margin-inline-start: 0.5rem;
   content: "\203A";
   font-size: 2.875rem;
 }

--- a/css/base/ckeditor5.css
+++ b/css/base/ckeditor5.css
@@ -51,7 +51,7 @@
 .btn.btn-start::after {
   position: relative;
   top: 7px;
-  margin-left: 0.5rem;
+  margin-inline-start: 0.5rem;
   content: "\203A" / "";
   font-size: 2.875rem;
 }
@@ -67,7 +67,7 @@
 
 /* Call out */
 .callout {
-  padding-left: 0.5rem;
+  padding-inline-start: 0.5rem;
   color: white;
   font-size: 1.3125rem;
   line-height: 2;

--- a/css/base/variables.css
+++ b/css/base/variables.css
@@ -257,6 +257,7 @@ body {
 
   /* File Upload Items */
   --file-upload-border: var(--border);
+  --file-upload-border-left-size: var(--border-width-large); /* Deprecated */
   --file-upload-border-inline-start-size: var(--border-width-large);
   --file-upload-border-color: var(--color-accent);
   --file-upload-bg-hover-color: var(--color-accent);
@@ -321,6 +322,7 @@ body {
 
   /* Quote */
   --quote-padding: var(--spacing-larger);
+  --quote-padding-left: var(--spacing-larger); /* Deprecated */
   --quote-padding-inline-start: var(--spacing-larger);
   --quote-border: var(--border-large);
   --quote-border-color: var(--color-accent);

--- a/css/base/variables.css
+++ b/css/base/variables.css
@@ -257,7 +257,7 @@ body {
 
   /* File Upload Items */
   --file-upload-border: var(--border);
-  --file-upload-border-left-size: var(--border-width-large);
+  --file-upload-border-inline-start-size: var(--border-width-large);
   --file-upload-border-color: var(--color-accent);
   --file-upload-bg-hover-color: var(--color-accent);
   --file-upload-text-hover-color: var(--color-white);
@@ -321,7 +321,7 @@ body {
 
   /* Quote */
   --quote-padding: var(--spacing-larger);
-  --quote-padding-left: var(--spacing-larger);
+  --quote-padding-inline-start: var(--spacing-larger);
   --quote-border: var(--border-large);
   --quote-border-color: var(--color-accent);
   --quote-bg-color: var(--color-grey-lighter);

--- a/css/components/add-to-calendar.css
+++ b/css/components/add-to-calendar.css
@@ -1,5 +1,5 @@
 .localgov-add-to-calendar:has(+ *) {
-  margin-bottom: var(--vertical-rhythm-spacing);
+  margin-block-end: var(--vertical-rhythm-spacing);
 }
 
 .localgov-add-to-calendar__trigger {
@@ -48,5 +48,5 @@
 }
 
 .localgov-add-to-calendar__item + .localgov-add-to-calendar__item {
-  margin-top: var(--spacing);
+  margin-block-start: var(--spacing);
 }

--- a/css/components/blog.css
+++ b/css/components/blog.css
@@ -6,12 +6,12 @@
 
 .field--name-localgov-blog-related-posts > .field__items > .field__item,
 .field--name-localgov-blog-related-posts > .field__item {
-  margin-bottom: var(--vertical-rhythm-spacing);
+  margin-block-end: var(--vertical-rhythm-spacing);
 }
 
 /* Featured posts */
 .lgd-blog__featured {
-  margin-bottom: var(--vertical-rhythm-spacing);
+  margin-block-end: var(--vertical-rhythm-spacing);
 }
 
 .field--name-localgov-blog-channel-featured > .field__items {
@@ -28,6 +28,6 @@
 }
 
 .view-localgov-blog-list .view-content {
-  padding-top: var(--vertical-rhythm-spacing);
-  border-top: var(--border);
+  padding-block-start: var(--vertical-rhythm-spacing);
+  border-block-start: var(--border);
 }

--- a/css/components/box-links.css
+++ b/css/components/box-links.css
@@ -1,14 +1,14 @@
 .box-links-listing {
-  margin-bottom: var(--vertical-rhythm-spacing);
+  margin-block-end: var(--vertical-rhythm-spacing);
 }
 
 .box-links-listing__list {
-  padding-left: 0;
+  padding-inline-start: 0;
 }
 
 .box-links-listing--boxes .box-links-listing__list-item,
 .box-links-listing__list .box-links-listing__list-item {
-  margin-bottom: var(--vertical-rhythm-spacing);
+  margin-block-end: var(--vertical-rhythm-spacing);
 }
 
 .box-links-listing__list-item::marker {
@@ -21,22 +21,22 @@
 }
 
 .box-link > * {
-  margin-bottom: var(--box-link-content-spacing);
-  padding-right: var(--box-link-content-spacing);
-  padding-left: var(--box-link-content-spacing);
+  margin-block-end: var(--box-link-content-spacing);
+  padding-inline-end: var(--box-link-content-spacing);
+  padding-inline-start: var(--box-link-content-spacing);
 }
 
 .box-link__image {
-  padding-right: 0;
-  padding-left: 0;
+  padding-inline-end: 0;
+  padding-inline-start: 0;
 }
 
 .box-link__title {
-  margin-top: var(--box-link-content-spacing);
+  margin-block-start: var(--box-link-content-spacing);
 }
 
 .box-link__image + .box-link__title {
-  margin-top: 0;
+  margin-block-start: 0;
 }
 
 .box-link__link::after {

--- a/css/components/breadcrumbs.css
+++ b/css/components/breadcrumbs.css
@@ -8,30 +8,30 @@
 */
 
 .lgd-region--breadcrumb {
-  margin-bottom: var(--breadcrumbs-spacing-bottom);
+  margin-block-end: var(--breadcrumbs-spacing-bottom);
   background-color: var(--breadcrumbs-background-color);
 }
 
 .breadcrumbs {
   padding: var(--breadcrumbs-padding-vertical) var(--breadcrumbs-padding-horizontal);
-  border-bottom: var(--breadcrumbs-border);
+  border-block-end: var(--breadcrumbs-border);
 }
 
 .breadcrumbs__list {
-  margin-bottom: 0;
-  padding-left: 0;
+  margin-block-end: 0;
+  padding-inline-start: 0;
   list-style: none;
 }
 
 .breadcrumbs__item {
   display: inline-block;
-  margin-right: 0.25rem;
+  margin-inline-end: 0.25rem;
   font-size: var(--breadcrumbs-font-size);
 }
 
 .breadcrumbs__item + .breadcrumbs__item::before {
   display: inline-block;
-  margin-right: 0.25rem;
+  margin-inline-end: 0.25rem;
   content: var(--breadcrumbs-divider);
   color: var(--breadcrumbs-link-color);
 }

--- a/css/components/callout-box.css
+++ b/css/components/callout-box.css
@@ -27,7 +27,7 @@
 @media screen and (min-width: 48rem) {
   .call-out-box--has-image .call-out-box__content {
     width: 75%;
-    padding-right: 20%;
+    padding-inline-end: 20%;
     background: linear-gradient(to right, var(--call-out-box-bg-color) 75%, transparent);
   }
 }

--- a/css/components/directories.css
+++ b/css/components/directories.css
@@ -6,7 +6,7 @@
 
 .localgov-directories-venue legend,
 .localgov-directories-page legend {
-  margin-bottom: var(--vertical-rhythm-spacing);
+  margin-block-end: var(--vertical-rhythm-spacing);
   font-size: var(--font-size-large);
   font-weight: bold;
 }
@@ -17,13 +17,13 @@
 }
 
 .localgov-directories-page fieldset .field + .field {
-  margin-top: var(--vertical-rhythm-spacing);
+  margin-block-start: var(--vertical-rhythm-spacing);
 }
 
 .localgov-directories-venue .field--name-location {
-  margin-bottom: var(--vertical-rhythm-spacing);
+  margin-block-end: var(--vertical-rhythm-spacing);
 }
 
 .localgov-directory__content .views-element-container + .views-element-container {
-  margin-top: var(--vertical-rhythm-spacing);
+  margin-block-start: var(--vertical-rhythm-spacing);
 }

--- a/css/components/embedded-views.css
+++ b/css/components/embedded-views.css
@@ -1,3 +1,3 @@
 .embedded-views__heading {
-  margin-bottom: var(--spacing-large);
+  margin-block-end: var(--spacing-large);
 }

--- a/css/components/events.css
+++ b/css/components/events.css
@@ -3,14 +3,14 @@
 }
 
 .field--name-localgov-event-image + .field--name-localgov-event-date {
-  margin-top: var(--vertical-rhythm-spacing);
+  margin-block-start: var(--vertical-rhythm-spacing);
 }
 
 .localgov-event .date-recur-date,
 .field--name-localgov-event-provider,
 .field--name-localgov-event-venue,
 .localgov-event .field--name-location > * {
-  margin-bottom: var(--vertical-rhythm-spacing);
+  margin-block-end: var(--vertical-rhythm-spacing);
 }
 
 .field--name-localgov-event-call-to-action a {

--- a/css/components/facets.css
+++ b/css/components/facets.css
@@ -1,13 +1,13 @@
 .facets-widget__list {
-  padding-left: 0;
+  padding-inline-start: 0;
 }
 
 .facets-widget__list + * {
-  margin-top: var(--vertical-rhythm-spacing);
+  margin-block-start: var(--vertical-rhythm-spacing);
 }
 
 .facet-item + .facet-item {
-  margin-top: var(--vertical-rhythm-spacing);
+  margin-block-start: var(--vertical-rhythm-spacing);
 }
 
 .facet-item::marker {

--- a/css/components/fact-box.css
+++ b/css/components/fact-box.css
@@ -1,5 +1,5 @@
 .fact-box {
-  margin-bottom: var(--vertical-rhythm-spacing);
+  margin-block-end: var(--vertical-rhythm-spacing);
   text-align: center;
   border: var(--fact-box-border);
   border-color: var(--fact-box-border-color);

--- a/css/components/featured-subsite.css
+++ b/css/components/featured-subsite.css
@@ -1,14 +1,14 @@
 .featured-subsite {
-  padding-bottom: var(--spacing);
+  padding-block-end: var(--spacing);
   background-color: var(--featured-subsite-bg-color);
 }
 .featured-subsite > * {
-  margin-bottom: var(--vertical-rhythm-spacing);
+  margin-block-end: var(--vertical-rhythm-spacing);
 }
 
 .featured-subsite > *:not(.featured-subsite__image) {
-  margin-right: var(--spacing-larger);
-  margin-left: var(--spacing-larger);
+  margin-inline-end: var(--spacing-larger);
+  margin-inline-start: var(--spacing-larger);
 }
 
 .featured-subsite__image img {

--- a/css/components/featured-teasers.css
+++ b/css/components/featured-teasers.css
@@ -3,7 +3,7 @@
 }
 
 .featured-teasers__teasers > .field__items > .field__item + .field__item {
-  margin-top: var(--vertical-rhythm-spacing);
+  margin-block-start: var(--vertical-rhythm-spacing);
 }
 
 .featured-teaser__content {

--- a/css/components/footer.css
+++ b/css/components/footer.css
@@ -1,10 +1,10 @@
 .lgd-footer {
-  margin-top: clamp(1rem, 10vw, var(--section-spacing-vertical-footer));
+  margin-block-start: clamp(1rem, 10vw, var(--section-spacing-vertical-footer));
 }
 
 .lgd-footer__pre-footer {
-  padding-top: clamp(1rem, 10vw, var(--section-spacing-vertical-pre-footer));
-  padding-bottom: clamp(1rem, 10vw, var(--section-spacing-vertical-pre-footer));
+  padding-block-start: clamp(1rem, 10vw, var(--section-spacing-vertical-pre-footer));
+  padding-block-end: clamp(1rem, 10vw, var(--section-spacing-vertical-pre-footer));
   color: var(--color-pre-footer-text);
   background-color: var(--color-section-pre-footer-bg);
 }
@@ -14,8 +14,8 @@
 }
 
 .lgd-footer__footer {
-  padding-top: clamp(1rem, 10vw, var(--section-spacing-vertical-footer));
-  padding-bottom: clamp(1rem, 10vw, var(--section-spacing-vertical-footer));
+  padding-block-start: clamp(1rem, 10vw, var(--section-spacing-vertical-footer));
+  padding-block-end: clamp(1rem, 10vw, var(--section-spacing-vertical-footer));
   color: var(--color-footer-text);
   background-color: var(--color-section-footer-bg);
 }
@@ -25,8 +25,8 @@
 }
 
 .lgd-footer__post-footer {
-  padding-top: clamp(1rem, 10vw, var(--section-spacing-vertical-post-footer));
-  padding-bottom: clamp(1rem, 10vw, var(--section-spacing-vertical-post-footer));
+  padding-block-start: clamp(1rem, 10vw, var(--section-spacing-vertical-post-footer));
+  padding-block-end: clamp(1rem, 10vw, var(--section-spacing-vertical-post-footer));
   color: var(--color-post-footer-text);
   background-color: var(--color-section-post-footer-bg);
 }

--- a/css/components/form-errors.css
+++ b/css/components/form-errors.css
@@ -7,11 +7,11 @@
 .form-item--error-message {
   padding: var(--spacing);
   border: 1px solid var(--color-danger);
-  border-bottom: 0;
+  border-block-end: 0;
   background-color: #fcf4f2;
 }
 
 .fieldset-wrapper .form-item--error-message {
-  margin-bottom: var(--spacing);
-  border-bottom: 1px solid var(--color-danger);
+  margin-block-end: var(--spacing);
+  border-block-end: 1px solid var(--color-danger);
 }

--- a/css/components/form-items.css
+++ b/css/components/form-items.css
@@ -2,7 +2,7 @@
 .facet-item,
 .form-item-webform-terms-of-service {
   position: relative;
-  margin-bottom: var(--spacing);
+  margin-block-end: var(--spacing);
 }
 
 fieldset,
@@ -20,7 +20,7 @@ legend {
 label,
 .webform-element--title-inline > label {
   display: block;
-  margin-bottom: 0;
+  margin-block-end: 0;
 }
 
 input[disabled] {
@@ -84,7 +84,7 @@ select:focus {
   padding: 0.5rem 1rem;
 }
 .select2-container .select2-selection--single .select2-selection__rendered {
-  padding-left: 0;
+  padding-inline-start: 0;
 }
 
 .select2-container--default .select2-selection--single .select2-selection__arrow {
@@ -150,7 +150,7 @@ input[type="submit"]:hover {
 .facet-item input[type="checkbox"] + label,
 .form-item-webform-terms-of-service input[type="checkbox"] + label {
   display: inline-block;
-  margin-left: 40px;
+  margin-inline-start: 40px;
   padding: 8px 15px 5px;
   cursor: pointer;
   touch-action: manipulation;
@@ -185,7 +185,7 @@ input[type="submit"]:hover {
   opacity: 0;
   border: solid;
   border-width: 0 0 5px 5px;
-  border-top-color: transparent;
+  border-block-start-color: transparent;
   background: transparent;
 }
 
@@ -233,8 +233,8 @@ input[type="submit"]:hover {
   display: block;
   clear: left;
   min-height: 40px;
-  margin-bottom: 10px;
-  padding-left: 40px;
+  margin-block-end: 10px;
+  padding-inline-start: 40px;
 }
 .webform-type-radios .form-item input,
 .webform-type-webform-radios-other .form-item-radios-other--radios input {
@@ -251,7 +251,7 @@ input[type="submit"]:hover {
 .webform-type-radios .form-item label,
 .webform-type-webform-radios-other .form-item-radios-other--radios label {
   display: inline-block;
-  margin-bottom: 0;
+  margin-block-end: 0;
   padding: 8px 15px 5px;
   cursor: pointer;
   touch-action: manipulation;
@@ -292,7 +292,7 @@ input[type="submit"]:hover {
 }
 .webform-type-radios .form-item:last-child,
 .webform-type-radios .form-item:last-of-type {
-  margin-bottom: 0;
+  margin-block-end: 0;
 }
 
 /* Description Field - needs to come before the file upload description items */
@@ -302,10 +302,10 @@ input[type="submit"]:hover {
   background-color: var(--form-item-description-bg-color);
 }
 .form-item input + .description {
-  border-top: 0;
+  border-block-start: 0;
 }
 .form-item .description + input {
-  border-top: 0;
+  border-block-start: 0;
 }
 
 .form-item .description .webform-element-more--content {
@@ -319,7 +319,7 @@ input[type="submit"]:hover {
 */
 .fieldset-wrapper > .field-prefix + .form-checkboxes,
 .fieldset-wrapper > .field-prefix + .form-item-radios {
-  margin-top: var(--spacing);
+  margin-block-start: var(--spacing);
 }
 
 /* File Upload */
@@ -331,7 +331,7 @@ input[type="file"],
   cursor: pointer;
   border: var(--file-upload-border);
   border-color: var(--file-upload-border-color);
-  border-left-width: var(--file-upload-border-left-size);
+  border-inline-start-width: var(--file-upload-border-inline-start-size);
 }
 input[type="file"]:focus,
 input[type="file"]:hover,
@@ -353,12 +353,12 @@ input[type="file"]:hover,
   max-width: 768px;
   border: var(--file-upload-border);
   border-color: var(--file-upload-border-color);
-  border-left-width: var(--file-upload-border-left-size);
+  border-inline-start-width: var(--file-upload-border-inline-start-size);
 }
 .form-item-managed-file .description br,
 .form-item-managed-file-multiple .description br,
 .form-item-managed-file-button .description br {
-  margin-bottom: var(--spacing);
+  margin-block-end: var(--spacing);
 }
 
 .facets-form fieldset {

--- a/css/components/guide-nav.css
+++ b/css/components/guide-nav.css
@@ -1,11 +1,11 @@
 .lgd-guide-nav {
-  margin-bottom: var(--vertical-rhythm-spacing);
+  margin-block-end: var(--vertical-rhythm-spacing);
   padding: var(--section-spacing-vertical-guide-nav) var(--section-spacing-horizontal-guide-nav);
   background-color: var(--color-grey-lighter);
 }
 
 .lgd-guide-nav__list {
-  margin-bottom: 0;
+  margin-block-end: 0;
   word-wrap: break-word;
 }
 
@@ -16,7 +16,7 @@
 }
 
 .lgd-guide-nav__list-item {
-  margin-bottom: var(--spacing);
+  margin-block-end: var(--spacing);
   font-size: var(--font-size-large);
   break-inside: avoid-column;
 }
@@ -35,6 +35,6 @@
 }
 
 .block-localgov-guides-contents {
-  margin-top: var(--spacing-largest);
-  margin-bottom: var(--spacing-largest);
+  margin-block-start: var(--spacing-largest);
+  margin-block-end: var(--spacing-largest);
 }

--- a/css/components/header.css
+++ b/css/components/header.css
@@ -12,8 +12,8 @@
 */
 
 .lgd-header {
-  padding-top: clamp(1rem, 10vw, var(--section-spacing-vertical-header));
-  padding-bottom: clamp(1rem, 10vw, var(--section-spacing-vertical-header));
+  padding-block-start: clamp(1rem, 10vw, var(--section-spacing-vertical-header));
+  padding-block-end: clamp(1rem, 10vw, var(--section-spacing-vertical-header));
   background-color: var(--color-section-header-bg);
 }
 
@@ -25,7 +25,7 @@
 }
 
 .lgd-header .lgd-region--header {
-  margin-right: calc(var(--spacing) * 2);
+  margin-inline-end: calc(var(--spacing) * 2);
 }
 
 /*
@@ -39,8 +39,8 @@
 
 .lgd-header__nav--primary,
 .lgd-header__nav--secondary {
-  margin-right: var(--spacing);
-  margin-left: var(--spacing);
+  margin-inline-end: var(--spacing);
+  margin-inline-start: var(--spacing);
 }
 
 .lgd-header__nav--primary {
@@ -73,15 +73,15 @@
 /* Theming the Header Toggles */
 .lgd-header__toggles {
   display: flex;
-  margin-right: var(--spacing);
-  margin-left: auto;
+  margin-inline-end: var(--spacing);
+  margin-inline-start: auto;
 }
 
 .lgd-header__toggle {
   display: flex;
   align-items: center;
   height: 100%;
-  margin-left: var(--spacing);
+  margin-inline-start: var(--spacing);
   padding: var(--spacing);
   cursor: pointer;
   color: var(--header-services-button-color);
@@ -98,12 +98,12 @@
 }
 
 .lgd-header__toggle-icon {
-  margin-left: var(--spacing-smaller);
+  margin-inline-start: var(--spacing-smaller);
 }
 
 .lgd-header__toggle-icon::after {
   display: inline-block;
-  margin-left: var(--spacing-smaller);
+  margin-inline-start: var(--spacing-smaller);
   content: "\203A" / "";
   transition: var(--transition-time);
   transform: rotate(90deg);
@@ -155,13 +155,13 @@
 
 /* Search Region */
 .lgd-region--search {
-  margin-top: var(--spacing);
-  margin-bottom: var(--spacing);
+  margin-block-start: var(--spacing);
+  margin-block-end: var(--spacing);
 }
 
 @media screen and (min-width: 48rem) {
   .lgd-region--search {
-    margin-left: auto;
+    margin-inline-start: auto;
   }
 }
 
@@ -177,7 +177,7 @@
 
 .lgd-region--search .form-item-s {
   flex-grow: 1;
-  margin-bottom: 0; /* Override default form-item class */
+  margin-block-end: 0; /* Override default form-item class */
 }
 
 @media screen and (min-width: 48rem) {
@@ -192,7 +192,7 @@
 }
 
 .lgd-region--search .form-actions {
-  margin-top: auto;
+  margin-block-start: auto;
 }
 
 .lgd-region--search .form-submit {

--- a/css/components/ia-block.css
+++ b/css/components/ia-block.css
@@ -1,5 +1,5 @@
 .ia-block {
-  margin-bottom: var(--spacing);
+  margin-block-end: var(--spacing);
   background-color: var(--ia-block-bg-color);
 }
 
@@ -11,12 +11,12 @@
 }
 
 .ia-block__title {
-  margin-top: 0;
+  margin-block-start: 0;
 }
 
 .ia-block li {
-  margin-bottom: 0.5rem;
+  margin-block-end: 0.5rem;
 }
 .ia-block li:last-of-type {
-  margin-bottom: 0;
+  margin-block-end: 0;
 }

--- a/css/components/image-with-caption.css
+++ b/css/components/image-with-caption.css
@@ -9,5 +9,5 @@
 }
 
 .lgd-image--has-caption *:last-of-type {
-  margin-bottom: 0;
+  margin-block-end: 0;
 }

--- a/css/components/key-contacts.css
+++ b/css/components/key-contacts.css
@@ -1,9 +1,9 @@
 .key-contacts .field--name-localgov-paragraphs > .field__item + .field__item {
-  margin-top: var(--vertical-rhythm-spacing);
-  padding-top: var(--vertical-rhythm-spacing);
-  border-top: var(--border);
+  margin-block-start: var(--vertical-rhythm-spacing);
+  padding-block-start: var(--vertical-rhythm-spacing);
+  border-block-start: var(--border);
 }
 
 .key-contact-item__content > * {
-  margin-top: var(--spacing);
+  margin-block-start: var(--spacing);
 }

--- a/css/components/link-and-summary.css
+++ b/css/components/link-and-summary.css
@@ -1,14 +1,14 @@
 .link-block__title-wrapper {
   display: flex;
   align-items: center;
-  margin-bottom: var(--vertical-rhythm-spacing);
+  margin-block-end: var(--vertical-rhythm-spacing);
 }
 
 .link-block__title-icon {
   flex-shrink: 0;
-  margin-right: var(--link-and-summary-title-icon-margin);
+  margin-inline-end: var(--link-and-summary-title-icon-margin);
 }
 
 .link-block__title {
-  margin-bottom: 0;
+  margin-block-end: 0;
 }

--- a/css/components/link.css
+++ b/css/components/link.css
@@ -5,7 +5,7 @@
 
 .link-icon {
   flex-shrink: 0;
-  margin-right: var(--link-icon-margin);
+  margin-inline-end: var(--link-icon-margin);
 }
 
 .link--button-style .link-wrapper {

--- a/css/components/localgov_eu_cookie_compliance.css
+++ b/css/components/localgov_eu_cookie_compliance.css
@@ -4,7 +4,7 @@
   This has been included to avoid the cookie compliance integration
   having a dependency on the base theme's variables for styling. By
   including this here, there will be sensible behaviour out-of-the-box.
-  
+
   End-users can override these styles in their descendant themes, if needed.
 
   This uses the .lgd-region path to increase specificity over that
@@ -13,6 +13,6 @@
 */
 
 .lgd-region .eu-cookie-compliance-save-preferences-button.spinning::before {
-  border-right: 3px solid var(--button-text-color-hover);
+  border-inline-end: 3px solid var(--button-text-color-hover);
   box-shadow: 0 0 2px 0 var(--button-text-color-hover);
 }

--- a/css/components/media-with-text.css
+++ b/css/components/media-with-text.css
@@ -55,13 +55,13 @@
 }
 
 .media-with-text--media-left .media-with-text__body {
-  padding-left: var(--spacing);
+  padding-inline-start: var(--spacing);
 }
 
 .media-with-text--media-right .media-with-text__body {
-  padding-right: var(--spacing);
+  padding-inline-end: var(--spacing);
 }
 
 .media-with-text--media-top .media-with-text__media {
-  margin-bottom: var(--spacing);
+  margin-block-end: var(--spacing);
 }

--- a/css/components/menu-main.css
+++ b/css/components/menu-main.css
@@ -6,8 +6,8 @@
 }
 
 .menu--main {
-  margin-bottom: 0;
-  padding-left: 0;
+  margin-block-end: 0;
+  padding-inline-start: 0;
   list-style: none;
 }
 
@@ -34,8 +34,8 @@
   }
 
   .menu--main > .menu-item {
-    margin-right: var(--spacing-smaller);
-    margin-left: var(--spacing-smaller);
+    margin-inline-end: var(--spacing-smaller);
+    margin-inline-start: var(--spacing-smaller);
   }
 
   .menu--main > .menu-item a {

--- a/css/components/messages.css
+++ b/css/components/messages.css
@@ -16,14 +16,14 @@
   overflow-wrap: break-word;
 }
 [dir="rtl"] .messages {
-  padding-right: 35px;
-  padding-left: 20px;
+  padding-inline-end: 35px;
+  padding-inline-start: 20px;
   text-align: right;
   border-width: 1px 0 1px 1px;
   background-position: right 10px top 21px;
 }
 .messages + .messages {
-  margin-top: 1.538em;
+  margin-block-start: 1.538em;
 }
 .messages__list {
   margin: 0;
@@ -31,7 +31,7 @@
   list-style: none;
 }
 .messages__item + .messages__item {
-  margin-top: 0.769em;
+  margin-block-start: 0.769em;
 }
 /* See .color-success in Seven's colors.css */
 .messages--status {
@@ -42,7 +42,7 @@
   box-shadow: -8px 0 0 #77b259; /* LTR */
 }
 [dir="rtl"] .messages--status {
-  margin-left: 0;
+  margin-inline-start: 0;
   border-color: #c9e1bd transparent #c9e1bd #c9e1bd;
   box-shadow: 8px 0 0 #77b259;
 }

--- a/css/components/news.css
+++ b/css/components/news.css
@@ -1,13 +1,13 @@
 .newsroom__featured-news {
-  margin-bottom: var(--newsroom-featured-bottom-space);
+  margin-block-end: var(--newsroom-featured-bottom-space);
 }
 
 .news-article__metadata-item--categories {
-  padding-left: 0;
+  padding-inline-start: 0;
 }
 
 .news-article__metadata-item + .news-article__metadata-item {
-  margin-top: var(--vertical-rhythm-spacing);
+  margin-block-start: var(--vertical-rhythm-spacing);
 }
 
 .news-article__category::marker {
@@ -19,5 +19,5 @@
 }
 
 .news-article__category + .news-article__category {
-  margin-left: var(--news-category-spacing);
+  margin-inline-start: var(--news-category-spacing);
 }

--- a/css/components/newsroom-teaser.css
+++ b/css/components/newsroom-teaser.css
@@ -1,5 +1,5 @@
 .newsroom-teaser > * + * {
-  margin-top: var(--vertical-rhythm-spacing);
+  margin-block-start: var(--vertical-rhythm-spacing);
 }
 
 .newsroom-teaser__title > a {

--- a/css/components/page-sections.css
+++ b/css/components/page-sections.css
@@ -31,36 +31,36 @@
   --color-page-section-text-color: var(--color-page-section-background-color-6-text-color);
 }
 
-.lgd-page-section--padding-top-small {
-  padding-top: var(--spacing-small);
+.lgd-page-section--padding-block-start-small {
+  padding-block-start: var(--spacing-small);
 }
-.lgd-page-section--padding-top-medium {
-  padding-top: var(--spacing);
+.lgd-page-section--padding-block-start-medium {
+  padding-block-start: var(--spacing);
 }
-.lgd-page-section--padding-top-large {
-  padding-top: var(--spacing-large);
+.lgd-page-section--padding-block-start-large {
+  padding-block-start: var(--spacing-large);
 }
-.lgd-page-section--padding-top-larger {
-  padding-top: var(--spacing-larger);
+.lgd-page-section--padding-block-start-larger {
+  padding-block-start: var(--spacing-larger);
 }
-.lgd-page-section--padding-top-largest {
-  padding-top: var(--spacing-largest);
+.lgd-page-section--padding-block-start-largest {
+  padding-block-start: var(--spacing-largest);
 }
 
-.lgd-page-section--padding-bottom-small {
-  padding-bottom: var(--spacing-small);
+.lgd-page-section--padding-block-end-small {
+  padding-block-end: var(--spacing-small);
 }
-.lgd-page-section--padding-bottom-medium {
-  padding-bottom: var(--spacing);
+.lgd-page-section--padding-block-end-medium {
+  padding-block-end: var(--spacing);
 }
-.lgd-page-section--padding-bottom-large {
-  padding-bottom: var(--spacing-large);
+.lgd-page-section--padding-block-end-large {
+  padding-block-end: var(--spacing-large);
 }
-.lgd-page-section--padding-bottom-larger {
-  padding-bottom: var(--spacing-larger);
+.lgd-page-section--padding-block-end-larger {
+  padding-block-end: var(--spacing-larger);
 }
-.lgd-page-section--padding-bottom-largest {
-  padding-bottom: var(--spacing-largest);
+.lgd-page-section--padding-block-end-largest {
+  padding-block-end: var(--spacing-largest);
 }
 
 .lgd-page-section--bg-colour-1,

--- a/css/components/page-sections.css
+++ b/css/components/page-sections.css
@@ -31,35 +31,35 @@
   --color-page-section-text-color: var(--color-page-section-background-color-6-text-color);
 }
 
-.lgd-page-section--padding-block-start-small {
+.lgd-page-section--padding-top-small {
   padding-block-start: var(--spacing-small);
 }
-.lgd-page-section--padding-block-start-medium {
+.lgd-page-section--padding-top-medium {
   padding-block-start: var(--spacing);
 }
-.lgd-page-section--padding-block-start-large {
+.lgd-page-section--padding-top-large {
   padding-block-start: var(--spacing-large);
 }
-.lgd-page-section--padding-block-start-larger {
+.lgd-page-section--padding-top-larger {
   padding-block-start: var(--spacing-larger);
 }
-.lgd-page-section--padding-block-start-largest {
+.lgd-page-section--padding-top-largest {
   padding-block-start: var(--spacing-largest);
 }
 
-.lgd-page-section--padding-block-end-small {
+.lgd-page-section--padding-bottom-small {
   padding-block-end: var(--spacing-small);
 }
-.lgd-page-section--padding-block-end-medium {
+.lgd-page-section--padding-bottom-medium {
   padding-block-end: var(--spacing);
 }
-.lgd-page-section--padding-block-end-large {
+.lgd-page-section--padding-bottom-large {
   padding-block-end: var(--spacing-large);
 }
-.lgd-page-section--padding-block-end-larger {
+.lgd-page-section--padding-bottom-larger {
   padding-block-end: var(--spacing-larger);
 }
-.lgd-page-section--padding-block-end-largest {
+.lgd-page-section--padding-bottom-largest {
   padding-block-end: var(--spacing-largest);
 }
 

--- a/css/components/page-title-block.css
+++ b/css/components/page-title-block.css
@@ -3,8 +3,8 @@
 */
 
 .lgd-page-title-block {
-  margin-bottom: var(--vertical-rhythm-spacing);
-  border-bottom: var(--page-title-border);
+  margin-block-end: var(--vertical-rhythm-spacing);
+  border-block-end: var(--page-title-border);
 }
 
 .lgd-page-title-block__title,

--- a/css/components/pager.css
+++ b/css/components/pager.css
@@ -2,13 +2,13 @@
   display: flex;
   flex-wrap: wrap;
   justify-content: center;
-  padding-left: 0;
+  padding-inline-start: 0;
   list-style-type: none;
 }
 
 .pager__item {
-  margin-right: var(--spacing-smaller);
-  margin-left: var(--spacing-smaller);
+  margin-inline-end: var(--spacing-smaller);
+  margin-inline-start: var(--spacing-smaller);
 }
 
 .pager__item::marker {

--- a/css/components/prev-next.css
+++ b/css/components/prev-next.css
@@ -1,6 +1,6 @@
 ul.lgd-prev-next__list {
   display: flex;
-  padding-left: 0;
+  padding-inline-start: 0;
   list-style-type: none;
 }
 /*
@@ -8,7 +8,7 @@ ul.lgd-prev-next__list {
   step-by-step module CSS. I'd prefer to use just .lgd-prev-next__list-item
 */
 ul.lgd-prev-next__list li.lgd-prev-next__list-item {
-  margin-right: 0.5rem;
+  margin-inline-end: 0.5rem;
 }
 
 .lgd-prev-next__link {
@@ -39,7 +39,7 @@ ul.lgd-prev-next__list li.lgd-prev-next__list-item {
 }
 
 .lgd-prev-next__list-item--prev .lgd-prev-next__title {
-  padding-left: var(--spacing-large);
+  padding-inline-start: var(--spacing-large);
 }
 
 .lgd-prev-next__icon path {
@@ -47,11 +47,11 @@ ul.lgd-prev-next__list li.lgd-prev-next__list-item {
 }
 
 .lgd-prev-next__icon--prev {
-  margin-right: 0.5rem;
+  margin-inline-end: 0.5rem;
 }
 
 .lgd-prev-next__icon--next {
-  margin-left: 0.5rem;
+  margin-inline-start: 0.5rem;
 }
 
 .lgd-prev-next__link:focus .lgd-prev-next__icon path,

--- a/css/components/preview-link.css
+++ b/css/components/preview-link.css
@@ -1,8 +1,8 @@
 .preview-link-form {
   max-width: var(--width-container);
-  margin-right: auto;
-  margin-bottom: var(--spacing);
-  margin-left: auto;
-  padding-right: var(--spacing);
-  padding-left: var(--spacing);
+  margin-inline-end: auto;
+  margin-block-end: var(--spacing);
+  margin-inline-start: auto;
+  padding-inline-end: var(--spacing);
+  padding-inline-start: var(--spacing);
 }

--- a/css/components/quote.css
+++ b/css/components/quote.css
@@ -1,9 +1,9 @@
 .pull-out-quote {
-  margin-top: 0;
-  margin-right: 0;
-  margin-left: 0;
+  margin-block-start: 0;
+  margin-inline-end: 0;
+  margin-inline-start: 0;
   padding: var(--quote-padding);
-  padding-left: var(--quote-padding-left);
+  padding-inline-start: var(--quote-padding-inline-start);
   border-color: var(--quote-border-color);
   border-inline-start: var(--quote-border);
   background-color: var(--quote-bg-color);
@@ -14,7 +14,7 @@
 }
 
 .pull-out-quote__author {
-  margin-top: var(--vertical-rhythm-spacing);
+  margin-block-start: var(--vertical-rhythm-spacing);
   color: var(--quote-author-color);
   font-weight: bold;
 }

--- a/css/components/region-tabs.css
+++ b/css/components/region-tabs.css
@@ -17,7 +17,7 @@
   display: flex;
   flex-wrap: wrap;
   margin: 0;
-  padding-left: 0;
+  padding-inline-start: 0;
   list-style: none;
 }
 

--- a/css/components/secondary-menu.css
+++ b/css/components/secondary-menu.css
@@ -1,6 +1,6 @@
 /* Theming Secondary Nav (services list region) */
 .region-secondary-menu {
-  margin-top: var(--spacing);
+  margin-block-start: var(--spacing);
   background-color: var(--secondary-menu-bg-color-first);
 }
 
@@ -10,7 +10,7 @@
 }
 
 .lgd-region__inner--secondary-menu .block-menu > h2 {
-  padding-left: var(--spacing-large);
+  padding-inline-start: var(--spacing-large);
 }
 
 .region-secondary-menu .menu {
@@ -35,7 +35,7 @@
 }
 
 .region-secondary-menu .menu-item {
-  margin-bottom: var(--spacing);
+  margin-block-end: var(--spacing);
 }
 
 .region-secondary-menu .menu-item > a {

--- a/css/components/service-cta-block.css
+++ b/css/components/service-cta-block.css
@@ -1,11 +1,11 @@
 .service-cta-block__list {
-  padding-left: 0;
+  padding-inline-start: 0;
   list-style: none;
-  border-bottom: var(--border);
+  border-block-end: var(--border);
 }
 
 .service-cta-block__list-item {
-  margin-bottom: var(--vertical-rhythm-spacing);
+  margin-block-end: var(--vertical-rhythm-spacing);
 }
 
 .service-cta-block__link {

--- a/css/components/service-landing-page.css
+++ b/css/components/service-landing-page.css
@@ -1,12 +1,12 @@
 .service-landing-page__contact {
-  margin-bottom: var(--vertical-rhythm-spacing);
+  margin-block-end: var(--vertical-rhythm-spacing);
   padding: var(--spacing);
-  border-left: var(--border-width-large) var(--border-style) var(--color-accent);
+  border-inline-start: var(--border-width-large) var(--border-style) var(--color-accent);
   background-color: var(--color-grey-lighter);
 }
 
 .service-landing-page__contact-list {
-  padding-left: 0;
+  padding-inline-start: 0;
 }
 
 .service-landing-page__contact-list-item,
@@ -16,7 +16,7 @@
 }
 
 .service-landing-page__contact-list-item + .service-landing-page__contact-list-item {
-  margin-top: var(--spacing-smaller);
+  margin-block-start: var(--spacing-smaller);
 }
 
 .service-landing-page__contact-map {
@@ -25,19 +25,19 @@
 }
 
 .service-landing-page__contact-icon {
-  margin-right: var(--spacing-smaller);
+  margin-inline-end: var(--spacing-smaller);
   line-height: 1;
 }
 
 .service-landing-page__contact h3 {
-  margin-bottom: 0;
+  margin-block-end: 0;
 }
 
 .service-landing-page__contact-containers {
-  margin-bottom: var(--vertical-rhythm-spacing);
-  padding-bottom: var(--vertical-rhythm-spacing);
-  border-bottom: var(--border);
-  border-bottom-color: var(--color-grey-medium);
+  margin-block-end: var(--vertical-rhythm-spacing);
+  padding-block-end: var(--vertical-rhythm-spacing);
+  border-block-end: var(--border);
+  border-block-end-color: var(--color-grey-medium);
 }
 
 .service-landing-page__service {
@@ -46,5 +46,5 @@
 
 .service-landing-page__service-icon svg {
   flex-shrink: 0;
-  margin-right: var(--spacing-small);
+  margin-inline-end: var(--spacing-small);
 }

--- a/css/components/service-statuses.css
+++ b/css/components/service-statuses.css
@@ -1,5 +1,5 @@
 .service-statuses {
-  margin-bottom: var(--spacing);
+  margin-block-end: var(--spacing);
   padding: var(--service-statuses-padding);
   background-color: var(--service-statuses-container-bg-color);
 }
@@ -13,11 +13,11 @@
 
 .service-statuses__header {
   justify-content: space-between;
-  padding-bottom: var(--service-statuses-padding);
+  padding-block-end: var(--service-statuses-padding);
 }
 
 .service-statuses__label {
-  margin-bottom: 0;
+  margin-block-end: 0;
   color: var(--service-statuses-container-text-color);
 }
 
@@ -28,12 +28,12 @@
 }
 
 .service-statuses__link--bottom {
-  margin-top: var(--service-statuses-padding);
+  margin-block-start: var(--service-statuses-padding);
 }
 
 .service-statuses .lgd-icon {
   display: inline-block;
-  margin-right: var(--spacing-smaller);
+  margin-inline-end: var(--spacing-smaller);
 }
 
 .service-statuses .lgd-icon path {
@@ -41,7 +41,7 @@
 }
 
 .service-statuses-list {
-  margin-bottom: 0;
+  margin-block-end: 0;
   padding: var(--service-statuses-padding);
   background-color: var(--service-statuses-list-bg-color);
 }
@@ -51,8 +51,8 @@
 }
 
 .service-statuses-list__item + .service-statuses-list__item {
-  margin-top: var(--service-statuses-list-spacing);
-  padding-top: var(--service-statuses-list-spacing);
+  margin-block-start: var(--service-statuses-list-spacing);
+  padding-block-start: var(--service-statuses-list-spacing);
   border-color: var(--service-statuses-list-border-color);
-  border-top: var(--service-statuses-list-border);
+  border-block-start: var(--service-statuses-list-border);
 }

--- a/css/components/sidebar.css
+++ b/css/components/sidebar.css
@@ -15,7 +15,7 @@
 
 .sidebar .lgd-region__inner > * + *,
 .newsroom__sidebar > * + * {
-  margin-top: var(--sidebar-exposed-form-item-spacing);
+  margin-block-start: var(--sidebar-exposed-form-item-spacing);
 }
 
 .sidebar .views-exposed-form label,
@@ -29,7 +29,7 @@
 .newsroom__sidebar .views-exposed-form .form-item + .form-item,
 .newsroom__sidebar .views-exposed-form .form-item + .form-actions,
 .newsroom__sidebar .form-item-search-api-fulltext > * + * {
-  margin-top: var(--sidebar-exposed-form-item-spacing);
+  margin-block-start: var(--sidebar-exposed-form-item-spacing);
 }
 
 .sidebar .views-exposed-form input,

--- a/css/components/sitewide-search.css
+++ b/css/components/sitewide-search.css
@@ -5,7 +5,7 @@
 }
 
 .lgd-search-results-list .view-header {
-  margin-bottom: var(--vertical-rhythm-spacing);
+  margin-block-end: var(--vertical-rhythm-spacing);
 }
 
 .lgd-search-results-list .views-exposed-form {
@@ -14,11 +14,11 @@
 }
 
 .lgd-search-results-list .form-item {
-  margin-bottom: 0;
+  margin-block-end: 0;
 }
 
 .lgd-search-results-list > * {
-  margin-bottom: var(--search-results-item-spacing);
+  margin-block-end: var(--search-results-item-spacing);
 }
 
 .lgd-search-results-list .views-exposed-form {
@@ -27,13 +27,13 @@
 }
 
 .lgd-search-results-list .item-list > * {
-  padding-left: 0;
+  padding-inline-start: 0;
 }
 
 .lgd-search-results-list .item-list > * li {
-  margin-bottom: var(--search-results-item-spacing);
-  padding-bottom: var(--search-results-item-spacing);
-  border-bottom: var(--search-results-list-item-border);
+  margin-block-end: var(--search-results-item-spacing);
+  padding-block-end: var(--search-results-item-spacing);
+  border-block-end: var(--search-results-list-item-border);
 }
 
 .lgd-search-results-list .item-list > * li::marker {
@@ -41,5 +41,5 @@
 }
 
 .search-result > .search-result__content > .field > *:last-of-type {
-  margin-bottom: 0;
+  margin-block-end: 0;
 }

--- a/css/components/step-by-step.css
+++ b/css/components/step-by-step.css
@@ -1,6 +1,6 @@
 /* Block container for step-by-step */
 .step-by-step-pages__relationship {
-  border-left-color: var(--step-by-step-relationship-border-color);
+  border-inline-start-color: var(--step-by-step-relationship-border-color);
 }
 
 /* Sidebar Block Header */

--- a/css/components/sticky-header.css
+++ b/css/components/sticky-header.css
@@ -5,11 +5,11 @@
 }
 
 .sticky-header--sticky .lgd-header + * {
-  margin-top: calc(var(--lgd-sticky-header-position) + var(--lgd-sticky-header-height));
+  margin-block-start: calc(var(--lgd-sticky-header-position) + var(--lgd-sticky-header-height));
   scroll-padding: var(--lgd-sticky-header-height);
 }
 
 .sticky-header-html,
 .sticky-header--sticky {
-  scroll-padding-top: var(--lgd-sticky-header-height);
+  scroll-padding-block-start: var(--lgd-sticky-header-height);
 }

--- a/css/components/subsites-menu.css
+++ b/css/components/subsites-menu.css
@@ -42,9 +42,13 @@
   --subsite-extra-link-bg-color-hover: var(--subsite-extra-color-contrast);
   --subsite-extra-menu-title-color: var(--subsite-extra-color-contrast);
   --subsite-extra-region-bg-color: var(--subsite-extra-color);
+  --subsite-extra-region-padding-left: var(--spacing); /* Deprecated */
   --subsite-extra-region-padding-inline-start: var(--spacing);
+  --subsite-extra-region-padding-right: var(--spacing); /* Deprecated */
   --subsite-extra-region-padding-inline-end: var(--spacing);
+  --subsite-extra-region-padding-top: var(--spacing); /* Deprecated */
   --subsite-extra-region-padding-block-start: var(--spacing);
+  --subsite-extra-region-padding-bottom: 0; /* Deprecated */
   --subsite-extra-region-padding-block-end: 0;
   --subsite-extra-menu-items-gap: var(--spacing);
   --subsite-extra-menu-title-font-family: var(--font-primary);
@@ -53,6 +57,7 @@
   --subsite-extra-link-spacing-inline: var(--spacing);
   --subsite-extra-link-spacing-block: var(--spacing);
   --subsite-extra-link-underline-thickness: max(3px, 0.1875rem, 0.12em);
+  --subsite-extra-header-padding-bottom: 0; /* Deprecated */
   --subsite-extra-header-padding-block-end: 0;
 }
 

--- a/css/components/subsites-menu.css
+++ b/css/components/subsites-menu.css
@@ -42,10 +42,10 @@
   --subsite-extra-link-bg-color-hover: var(--subsite-extra-color-contrast);
   --subsite-extra-menu-title-color: var(--subsite-extra-color-contrast);
   --subsite-extra-region-bg-color: var(--subsite-extra-color);
-  --subsite-extra-region-padding-left: var(--spacing);
-  --subsite-extra-region-padding-right: var(--spacing);
-  --subsite-extra-region-padding-top: var(--spacing);
-  --subsite-extra-region-padding-bottom: 0;
+  --subsite-extra-region-padding-inline-start: var(--spacing);
+  --subsite-extra-region-padding-inline-end: var(--spacing);
+  --subsite-extra-region-padding-block-start: var(--spacing);
+  --subsite-extra-region-padding-block-end: 0;
   --subsite-extra-menu-items-gap: var(--spacing);
   --subsite-extra-menu-title-font-family: var(--font-primary);
   --subsite-extra-border-color: var(--subsite-extra-color);
@@ -53,7 +53,7 @@
   --subsite-extra-link-spacing-inline: var(--spacing);
   --subsite-extra-link-spacing-block: var(--spacing);
   --subsite-extra-link-underline-thickness: max(3px, 0.1875rem, 0.12em);
-  --subsite-extra-header-padding-bottom: 0;
+  --subsite-extra-header-padding-block-end: 0;
 }
 
 /*
@@ -63,15 +63,15 @@
   subsites menu. To reverse it, simply set the variable value to var(--spacing).
 */
 .subsite-extra:has(.lgd-region--subsites-menu) .lgd-header {
-  padding-bottom: var(--subsite-extra-header-padding-bottom);
+  padding-block-end: var(--subsite-extra-header-padding-block-end);
 }
 
 /* This would be changed in the menu-subsites.css */
 .lgd-region--subsites-menu {
-  padding-top: var(--subsite-extra-region-padding-top);
-  padding-right: var(--subsite-extra-region-padding-right);
-  padding-bottom: var(--subsite-extra-region-padding-bottom);
-  padding-left: var(--subsite-extra-region-padding-left);
+  padding-block-start: var(--subsite-extra-region-padding-block-start);
+  padding-inline-end: var(--subsite-extra-region-padding-inline-end);
+  padding-block-end: var(--subsite-extra-region-padding-block-end);
+  padding-inline-start: var(--subsite-extra-region-padding-inline-start);
   background-color: var(--subsite-extra-region-bg-color);
 }
 
@@ -89,7 +89,7 @@
 }
 
 .lgd-region--subsites-menu .subsite-extra__title {
-  margin-bottom: 0;
+  margin-block-end: 0;
 }
 
 .lgd-region--subsites-menu .subsite-extra__title > a {
@@ -106,9 +106,9 @@
   display: flex;
   flex-wrap: wrap;
   gap: var(--subsite-extra-menu-items-gap);
-  margin-top: var(--spacing);
-  margin-bottom: 0;
-  padding-left: 0;
+  margin-block-start: var(--spacing);
+  margin-block-end: 0;
+  padding-inline-start: 0;
   list-style: none;
 }
 

--- a/css/components/tabs.css
+++ b/css/components/tabs.css
@@ -32,10 +32,10 @@
 }
 
 .tabs--initialised .tabs__controls [aria-selected="true"] {
-  border-bottom-color: var(--tabs-button-active-color);
+  border-block-end-color: var(--tabs-button-active-color);
   background-color: var(--tabs-button-active-color);
 }
 
 .tabs--initialised .tabs__controls > li + li button {
-  border-left: none;
+  border-inline-start: none;
 }

--- a/css/components/teaser.css
+++ b/css/components/teaser.css
@@ -7,7 +7,7 @@
 }
 
 .lgd-teaser__content + .lgd-teaser__image {
-  margin-top: var(--spacing);
+  margin-block-start: var(--spacing);
 }
 
 @media screen and (min-width: 48rem) {
@@ -22,13 +22,13 @@
   }
 
   .lgd-teaser__image + .lgd-teaser__content {
-    margin-left: 1rem;
+    margin-inline-start: 1rem;
   }
 
   .lgd-teaser__content + .lgd-teaser__image {
-    margin-top: 0;
-    margin-left: auto;
-    padding-left: 1rem;
+    margin-block-start: 0;
+    margin-inline-start: auto;
+    padding-inline-start: 1rem;
   }
 
   /*
@@ -48,7 +48,7 @@
     padding: var(--teaser-featured-content-padding);
   }
   .newsroom__featured-news .lgd-teaser__image + .lgd-teaser__content {
-    margin-left: 0;
+    margin-inline-start: 0;
   }
 }
 
@@ -63,9 +63,9 @@
 .lgd-teaser-list .service-landing-page__service,
 .lgd-teaser-list .lgd-topic-list-builder__service,
 .news-article .field--name-localgov-news-related > .field__item {
-  margin-bottom: var(--vertical-rhythm-spacing);
-  padding-bottom: var(--vertical-rhythm-spacing);
-  border-bottom: var(--border);
+  margin-block-end: var(--vertical-rhythm-spacing);
+  padding-block-end: var(--vertical-rhythm-spacing);
+  border-block-end: var(--border);
 }
 
 .lgd-teaser-list--grid .view-content,

--- a/css/components/term.css
+++ b/css/components/term.css
@@ -1,36 +1,36 @@
 .lgd-term__image {
-  margin-bottom: var(--vertical-rhythm-spacing);
+  margin-block-end: var(--vertical-rhythm-spacing);
 }
 
 @media screen and (min-width: 48rem) {
 
   .lgd-term {
     display: flex;
-    margin-bottom: var(--blog-author-content-margin);
+    margin-block-end: var(--blog-author-content-margin);
   }
 
   .lgd-term__image {
     flex-shrink: 0;
     width: var(--blog-author-image-width);
-    margin-bottom: 0;
+    margin-block-end: 0;
   }
 
   .lgd-term__image ~ .lgd-term__content {
-    margin-left: var(--vertical-rhythm-spacing);
+    margin-inline-start: var(--vertical-rhythm-spacing);
   }
 }
 
 .view-taxonomy-term .view-content {
-  padding-top: var(--vertical-rhythm-spacing);
-  border-top: var(--border);
+  padding-block-start: var(--vertical-rhythm-spacing);
+  border-block-start: var(--border);
 }
 
 .view-taxonomy-term .views-row {
-  margin-bottom: var(--vertical-rhythm-spacing);
-  padding-bottom: var(--vertical-rhythm-spacing);
-  border-bottom: var(--border);
+  margin-block-end: var(--vertical-rhythm-spacing);
+  padding-block-end: var(--vertical-rhythm-spacing);
+  border-block-end: var(--border);
 }
 
 .feed-icons {
-  margin-bottom: var(--vertical-rhythm-spacing);
+  margin-block-end: var(--vertical-rhythm-spacing);
 }

--- a/css/components/topic-list-builder.css
+++ b/css/components/topic-list-builder.css
@@ -8,19 +8,19 @@
 
 .lgd-topic-list-builder__service-icon svg {
   flex-shrink: 0;
-  margin-right: var(--spacing-small);
+  margin-inline-end: var(--spacing-small);
 }
 
 .lgd-topic-list-builder .field--name-topic-list-term {
-  margin-bottom: var(--vertical-rhythm-spacing);
+  margin-block-end: var(--vertical-rhythm-spacing);
 }
 
 .lgd-topic-list-builder__show-more {
   display: flex;
   align-items: center;
-  margin-bottom: var(--vertical-rhythm-spacing);
+  margin-block-end: var(--vertical-rhythm-spacing);
 }
 
 .lgd-topic-list-builder__show-more .lgd-icon {
-  margin-right: var(--spacing-smaller);
+  margin-inline-end: var(--spacing-smaller);
 }

--- a/css/components/video.css
+++ b/css/components/video.css
@@ -1,7 +1,7 @@
 /* Video player  */
 .field--name-field-media-oembed-video {
   position: relative;
-  padding-bottom: 56.25%;
+  padding-block-end: 56.25%;
   /* 16:9, for an aspect ratio of 1:1 change to this value to 100% */
 }
 

--- a/css/components/wysiwyg-styles.css
+++ b/css/components/wysiwyg-styles.css
@@ -52,7 +52,7 @@
 .btn.btn-start::after {
   position: relative;
   top: var(--btn-start-icon-top);
-  margin-left: 0.5rem;
+  margin-inline-start: 0.5rem;
   content: var(--btn-start-icon) / "";
   font-size: var(--btn-start-icon-size);
   line-height: 0;
@@ -63,7 +63,7 @@
   display: inline-block;
   width: 0.75rem;
   height: 0.75rem;
-  margin-left: 0.25rem;
+  margin-inline-start: 0.25rem;
   content: "";
   background-color: var(--external-link-icon-color); /* https://stackoverflow.com/questions/51395179/svg-fill-with-css-variables#58536915 */
   -webkit-mask-image: url("../../templates/includes/icons/external-link.svg");

--- a/css/layout/grid.css
+++ b/css/layout/grid.css
@@ -31,8 +31,8 @@
 }
 
 .lgd-row > * {
-  margin-right: calc(var(--grid-column-spacing) / 2);
-  margin-left: calc(var(--grid-column-spacing) / 2);
+  margin-inline-end: calc(var(--grid-column-spacing) / 2);
+  margin-inline-start: calc(var(--grid-column-spacing) / 2);
 }
 
 .lgd-row__one-quarter,

--- a/css/layout/layout-utilities.css
+++ b/css/layout/layout-utilities.css
@@ -15,8 +15,8 @@
 */
 .lgd-container {
   max-width: var(--width-container);
-  margin-right: auto;
-  margin-left: auto;
+  margin-inline-end: auto;
+  margin-inline-start: auto;
 }
 .lgd-container--mega {
   max-width: var(--width-mega);
@@ -35,8 +35,8 @@
 }
 
 .padding-horizontal {
-  padding-right: var(--spacing-padding-horizontal);
-  padding-left: var(--spacing-padding-horizontal);
+  padding-inline-end: var(--spacing-padding-horizontal);
+  padding-inline-start: var(--spacing-padding-horizontal);
 }
 
 .lgd-icon svg {
@@ -64,5 +64,5 @@
 }
 
 .layout__region > * {
-  margin-bottom: var(--vertical-rhythm-spacing);
+  margin-block-end: var(--vertical-rhythm-spacing);
 }


### PR DESCRIPTION
Closes #628 

## What does this change?

Removes all instances of things like `margin-left`, `margin-right`, etc and use logical properties for them instead, such as `margin-inline-start` and `margin-inline-end`. 

This will be very beneficial for any site that wants to use languages other than left-to-right languages. It will be even more beneficial if we scale the project beyond UK/Ireland. Oh, and it will also mean a smaller CSS codebase to maintain.

## How to test

- Checkout this branch
- Load the demo content module
- Make sure everything looks exactly as it did before

## How can we measure success?

We only have to write one set of CSS rules, no matter what direction our language is in.

## Have you considered any issues?

This PR changes the names of all our properties such as `margin-left` but also all our custom variables such as `--quote-padding-left: var(--spacing-larger);` becoming `--quote-padding-inline-start: var(--spacing-larger);`.

### Solutions - 1: Release Notes
We will need to make sure we have release notes for people to update anywhere they have used those variables (it should be a simple enough find/replace task).

### Solutions - 2: Mapped variables
We could create new variables and map those to the old ones, such as:
- `--quote-padding-inline-start: var(--quote-padding-left);`

