### PR TITLE
adds CSS to allow tables to scroll on small screens

### DIFF
--- a/css/base/base.css
+++ b/css/base/base.css
@@ -203,6 +203,10 @@ th {
 }
 
 /* Responsive tables for table field tables */
+.field--name-localgov-table {
+  max-width: 100%;
+  overflow-x: hidden;
+}
 .tablefield-wrapper {
   overflow-inline: auto;
 }

--- a/css/base/base.css
+++ b/css/base/base.css
@@ -202,6 +202,11 @@ th {
   background-color: var(--table-bg-color);
 }
 
+/* Responsive tables for table field tables */
+.tablefield-wrapper {
+  overflow-inline: auto;
+}
+
 input,
 select,
 option,

--- a/css/base/base.css
+++ b/css/base/base.css
@@ -208,7 +208,7 @@ th {
   overflow-x: hidden;
 }
 .tablefield-wrapper {
-  overflow-inline: auto;
+  overflow-x: auto;
 }
 
 input,

--- a/css/layout/layout-utilities.css
+++ b/css/layout/layout-utilities.css
@@ -63,6 +63,10 @@
   width: var(--spacing-smallest);
 }
 
+.layout__region {
+  max-width: 100%;
+}
+
 .layout__region > * {
   margin-bottom: var(--vertical-rhythm-spacing);
 }


### PR DESCRIPTION
Closes #579 

## What does this change?

1. Sets `.layout__region` and `.field--table` to `max-width: 100%`, so they don't overflow with any tables (or other elements)
2. Sets the .tablefield-wrapper to use `overflow-x: auto` so if it's too wide, it will have a horizonal scroll.

## How to test

1. Visit /test-subsite-demo-all-components/example-page-tables-and-tabs on a small screen and check that only the table has horizontal scroll, not the whole page.

---
Thanks to [Big Blue Door](https://www.bigbluedoor.net/) for sponsoring my time to work on this.