### PR TITLE
sets input borders to darker grey

### DIFF
--- a/css/base/variables.css
+++ b/css/base/variables.css
@@ -234,8 +234,8 @@ body {
   --input-text-color-hover: var(--color-accent);
   --input-icon-color: var(--input-text-color);
   --input-icon-color-hover: var(--color-accent);
-  --input-border-color: var(--color-grey-medium);
-  --input-border-color-hover: var(--color-grey-medium);
+  --input-border-color: var(--color-grey-dark);
+  --input-border-color-hover: var(--color-grey-dark);
   --input-bg-color: var(--color-white);
   --input-bg-color-hover: var(--color-grey-light);
   --input-border-radius: 0;


### PR DESCRIPTION
Closes #642 

## What does this change?

Sets the border on input elements to a darker grey, so it has better contrast against the light grey in the sidebar.

## How to test

Enable demo content module, go to the /news page, check there is sufficient contrast between the sidebar background colour and the border on the search input.

---
Thanks to [Big Blue Door](https://www.bigbluedoor.net/) for sponsoring my time to work on this.