### PR TITLE
streamlines *-block-* and *-inline-* css properties

### DIFF
--- a/css/components/box-links.css
+++ b/css/components/box-links.css
@@ -22,13 +22,11 @@
 
 .box-link > * {
   margin-block-end: var(--box-link-content-spacing);
-  padding-inline-end: var(--box-link-content-spacing);
-  padding-inline-start: var(--box-link-content-spacing);
+  padding-inline: var(--box-link-content-spacing);
 }
 
 .box-link__image {
-  padding-inline-end: 0;
-  padding-inline-start: 0;
+  padding-inline: 0;
 }
 
 .box-link__title {

--- a/css/components/featured-subsite.css
+++ b/css/components/featured-subsite.css
@@ -7,8 +7,7 @@
 }
 
 .featured-subsite > *:not(.featured-subsite__image) {
-  margin-inline-end: var(--spacing-larger);
-  margin-inline-start: var(--spacing-larger);
+  margin-inline: var(--spacing-larger);
 }
 
 .featured-subsite__image img {

--- a/css/components/footer.css
+++ b/css/components/footer.css
@@ -3,8 +3,7 @@
 }
 
 .lgd-footer__pre-footer {
-  padding-block-start: clamp(1rem, 10vw, var(--section-spacing-vertical-pre-footer));
-  padding-block-end: clamp(1rem, 10vw, var(--section-spacing-vertical-pre-footer));
+  padding-block: clamp(1rem, 10vw, var(--section-spacing-vertical-pre-footer));
   color: var(--color-pre-footer-text);
   background-color: var(--color-section-pre-footer-bg);
 }
@@ -14,8 +13,7 @@
 }
 
 .lgd-footer__footer {
-  padding-block-start: clamp(1rem, 10vw, var(--section-spacing-vertical-footer));
-  padding-block-end: clamp(1rem, 10vw, var(--section-spacing-vertical-footer));
+  padding-block: clamp(1rem, 10vw, var(--section-spacing-vertical-footer));
   color: var(--color-footer-text);
   background-color: var(--color-section-footer-bg);
 }
@@ -25,8 +23,7 @@
 }
 
 .lgd-footer__post-footer {
-  padding-block-start: clamp(1rem, 10vw, var(--section-spacing-vertical-post-footer));
-  padding-block-end: clamp(1rem, 10vw, var(--section-spacing-vertical-post-footer));
+  padding-block: clamp(1rem, 10vw, var(--section-spacing-vertical-post-footer));
   color: var(--color-post-footer-text);
   background-color: var(--color-section-post-footer-bg);
 }

--- a/css/components/guide-nav.css
+++ b/css/components/guide-nav.css
@@ -35,6 +35,5 @@
 }
 
 .block-localgov-guides-contents {
-  margin-block-start: var(--spacing-largest);
-  margin-block-end: var(--spacing-largest);
+  margin-block: var(--spacing-largest);
 }

--- a/css/components/header.css
+++ b/css/components/header.css
@@ -12,8 +12,7 @@
 */
 
 .lgd-header {
-  padding-block-start: clamp(1rem, 10vw, var(--section-spacing-vertical-header));
-  padding-block-end: clamp(1rem, 10vw, var(--section-spacing-vertical-header));
+  padding-block: clamp(1rem, 10vw, var(--section-spacing-vertical-header));
   background-color: var(--color-section-header-bg);
 }
 
@@ -39,8 +38,7 @@
 
 .lgd-header__nav--primary,
 .lgd-header__nav--secondary {
-  margin-inline-end: var(--spacing);
-  margin-inline-start: var(--spacing);
+  margin-inline: var(--spacing);
 }
 
 .lgd-header__nav--primary {
@@ -155,8 +153,7 @@
 
 /* Search Region */
 .lgd-region--search {
-  margin-block-start: var(--spacing);
-  margin-block-end: var(--spacing);
+  margin-block: var(--spacing);
 }
 
 @media screen and (min-width: 48rem) {

--- a/css/components/menu-main.css
+++ b/css/components/menu-main.css
@@ -34,8 +34,7 @@
   }
 
   .menu--main > .menu-item {
-    margin-inline-end: var(--spacing-smaller);
-    margin-inline-start: var(--spacing-smaller);
+    margin-inline: var(--spacing-smaller);
   }
 
   .menu--main > .menu-item a {

--- a/css/components/pager.css
+++ b/css/components/pager.css
@@ -7,8 +7,7 @@
 }
 
 .pager__item {
-  margin-inline-end: var(--spacing-smaller);
-  margin-inline-start: var(--spacing-smaller);
+  margin-inline: var(--spacing-smaller);
 }
 
 .pager__item::marker {

--- a/css/components/preview-link.css
+++ b/css/components/preview-link.css
@@ -1,8 +1,6 @@
 .preview-link-form {
   max-width: var(--width-container);
-  margin-inline-end: auto;
   margin-block-end: var(--spacing);
-  margin-inline-start: auto;
-  padding-inline-end: var(--spacing);
-  padding-inline-start: var(--spacing);
+  margin-inline: auto;
+  padding-inline: var(--spacing);
 }

--- a/css/components/quote.css
+++ b/css/components/quote.css
@@ -1,7 +1,6 @@
 .pull-out-quote {
   margin-block-start: 0;
-  margin-inline-end: 0;
-  margin-inline-start: 0;
+  margin-inline: 0;
   padding: var(--quote-padding);
   padding-inline-start: var(--quote-padding-inline-start);
   border-color: var(--quote-border-color);

--- a/css/components/subsites-menu.css
+++ b/css/components/subsites-menu.css
@@ -73,10 +73,8 @@
 
 /* This would be changed in the menu-subsites.css */
 .lgd-region--subsites-menu {
-  padding-block-start: var(--subsite-extra-region-padding-block-start);
-  padding-inline-end: var(--subsite-extra-region-padding-inline-end);
-  padding-block-end: var(--subsite-extra-region-padding-block-end);
-  padding-inline-start: var(--subsite-extra-region-padding-inline-start);
+  padding-block: var(--subsite-extra-region-padding-block-end);
+  padding-inline: var(--subsite-extra-region-padding-inline-end);
   background-color: var(--subsite-extra-region-bg-color);
 }
 

--- a/css/layout/grid.css
+++ b/css/layout/grid.css
@@ -31,8 +31,7 @@
 }
 
 .lgd-row > * {
-  margin-inline-end: calc(var(--grid-column-spacing) / 2);
-  margin-inline-start: calc(var(--grid-column-spacing) / 2);
+  margin-inline: calc(var(--grid-column-spacing) / 2);
 }
 
 .lgd-row__one-quarter,

--- a/css/layout/layout-utilities.css
+++ b/css/layout/layout-utilities.css
@@ -15,8 +15,7 @@
 */
 .lgd-container {
   max-width: var(--width-container);
-  margin-inline-end: auto;
-  margin-inline-start: auto;
+  margin-inline: auto;
 }
 .lgd-container--mega {
   max-width: var(--width-mega);
@@ -35,8 +34,7 @@
 }
 
 .padding-horizontal {
-  padding-inline-end: var(--spacing-padding-horizontal);
-  padding-inline-start: var(--spacing-padding-horizontal);
+  padding-inline: var(--spacing-padding-horizontal);
 }
 
 .lgd-icon svg {


### PR DESCRIPTION
Closes #651 

## What does this change?

Removes longer form css rules for block and inline level items. Instead of having, for example, `margin-left` and `margin-right` we now just have `margin-inline` on a property.

## How to test

Just make sure everything still looks as it should.

## How can we measure success?

We have a smaller CSS footprint. Go environment!

---
Thanks to [Big Blue Door](https://www.bigbluedoor.net/) for sponsoring my time to work on this.