### PR TITLE
adds spacing below features news items

### DIFF
--- a/css/base/variables.css
+++ b/css/base/variables.css
@@ -415,6 +415,7 @@ body {
   /* News */
   --newsroom-featured-bottom-space: var(--spacing-largest);
   --news-category-spacing: var(--spacing);
+  --newsroom-featured-space-after-items: var(--spacing);
 
   /* Search Results */
   --sitewide-search-header-container-padding-horizontal: var(--spacing);

--- a/css/components/news.css
+++ b/css/components/news.css
@@ -2,6 +2,10 @@
   margin-block-end: var(--newsroom-featured-bottom-space);
 }
 
+.newsroom__featured-news > .lgd-row > * {
+  margin-block-end: var(--newsroom-featured-space-after-items);
+}
+
 .news-article__metadata-item--categories {
   padding-inline-start: 0;
 }


### PR DESCRIPTION
Closes #657 

## What does this change?

Adds margin below each featured news item on small screens.

Before:

![Screenshot 2024-11-21 at 11 19 49](https://github.com/user-attachments/assets/32936e21-37b5-4355-9209-a341ef927dcd)

After:

![Screenshot 2024-11-21 at 11 21 17](https://github.com/user-attachments/assets/bfc7ce7e-1630-4bea-b8af-69179a9cdc74)

---
Thanks to [Big Blue Door](https://www.bigbluedoor.net/) for sponsoring my time to work on this.
