### PR TITLE
Adds templates + CSS for the card view mode

### DIFF
--- a/css/base/variables.css
+++ b/css/base/variables.css
@@ -412,6 +412,12 @@ body {
   --teaser-featured-border: var(--border);
   --teaser-featured-border-color: var(--border-color-dark);
 
+  /* Card View Mode */
+  --card-featured-height: var(--teaser-featured-height);
+  --card-featured-border: var(--teaser-featured-border);
+  --card-featured-border-color: var(--teaser-featured-border-color);
+  --card-featured-content-padding: var(--teaser-featured-content-padding);
+
   /* News */
   --newsroom-featured-bottom-space: var(--spacing-largest);
   --news-category-spacing: var(--spacing);

--- a/css/base/variables.css
+++ b/css/base/variables.css
@@ -413,10 +413,10 @@ body {
   --teaser-featured-border-color: var(--border-color-dark);
 
   /* Card View Mode */
-  --card-featured-height: var(--teaser-featured-height);
-  --card-featured-border: var(--teaser-featured-border);
-  --card-featured-border-color: var(--teaser-featured-border-color);
-  --card-featured-content-padding: var(--teaser-featured-content-padding);
+  --card-height: var(--teaser-featured-height);
+  --card-border: var(--teaser-featured-border);
+  --card-border-color: var(--teaser-featured-border-color);
+  --card-content-padding: var(--teaser-featured-content-padding);
 
   /* News */
   --newsroom-featured-bottom-space: var(--spacing-largest);

--- a/css/components/card.css
+++ b/css/components/card.css
@@ -4,9 +4,9 @@
 
 .lgd-card {
   display: block;
-  height: var(--card-featured-height);
-  border: var(--card-featured-border);
-  border-color: var(--card-featured-border-color);
+  height: var(--card-height);
+  border: var(--card-border);
+  border-color: var(--card-border-color);
 }
 .lgd-card__image {
   width: 100%;
@@ -17,7 +17,7 @@
 }
 
 .lgd-card__content {
-  padding: var(--card-featured-content-padding);
+  padding: var(--card-content-padding);
 }
 
 .lgd-card__image + .lgd-card__content {

--- a/css/components/card.css
+++ b/css/components/card.css
@@ -1,0 +1,25 @@
+/*
+  @file Theming the card view mode, and lists that render teasers.
+*/
+
+.lgd-card {
+  display: block;
+  height: var(--card-featured-height);
+  border: var(--card-featured-border);
+  border-color: var(--card-featured-border-color);
+}
+.lgd-card__image {
+  width: 100%;
+}
+
+.lgd-card__image img {
+  width: 100%;
+}
+
+.lgd-card__content {
+  padding: var(--card-featured-content-padding);
+}
+
+.lgd-card__image + .lgd-card__content {
+  margin-inline-start: 0;
+}

--- a/localgov_base.libraries.yml
+++ b/localgov_base.libraries.yml
@@ -127,6 +127,11 @@ teaser:
     theme:
       css/components/teaser.css: {}
 
+card:
+  css:
+    theme:
+      css/components/card.css: {}
+
 page-sections:
   css:
     theme:

--- a/templates/content/node--localgov-card.html.twig
+++ b/templates/content/node--localgov-card.html.twig
@@ -1,0 +1,124 @@
+{#
+/**
+ * @file
+ * Theme override to display a node.
+ *
+ * Available variables:
+ * - node: The node entity with limited access to object properties and methods.
+ *   Only method names starting with "get", "has", or "is" and a few common
+ *   methods such as "id", "label", and "bundle" are available. For example:
+ *   - node.getCreatedTime() will return the node creation timestamp.
+ *   - node.hasField('field_example') returns TRUE if the node bundle includes
+ *     field_example. (This does not indicate the presence of a value in this
+ *     field.)
+ *   - node.isPublished() will return whether the node is published or not.
+ *   Calling other methods, such as node.delete(), will result in an exception.
+ *   See \Drupal\node\Entity\Node for a full list of public properties and
+ *   methods for the node object.
+ * - label: (optional) The title of the node.
+ * - content: All node items. Use {{ content }} to print them all,
+ *   or print a subset such as {{ content.field_example }}. Use
+ *   {{ content|without('field_example') }} to temporarily suppress the printing
+ *   of a given child element.
+ * - author_picture: The node author user entity, rendered using the "compact"
+ *   view mode.
+ * - metadata: Metadata for this node.
+ * - date: (optional) Themed creation date field.
+ * - author_name: (optional) Themed author name field.
+ * - url: Direct URL of the current node.
+ * - display_submitted: Whether submission information should be displayed.
+ * - attributes: HTML attributes for the containing element.
+ *   The attributes.class element may contain one or more of the following
+ *   classes:
+ *   - node: The current template type (also known as a "theming hook").
+ *   - node--type-[type]: The current node type. For example, if the node is an
+ *     "Article" it would result in "node--type-article". Note that the machine
+ *     name will often be in a short form of the human readable label.
+ *   - node--view-mode-[view_mode]: The View Mode of the node; for example, a
+ *     teaser would result in: "node--view-mode-teaser", and
+ *     full: "node--view-mode-full".
+ *   The following are controlled through the node publishing options.
+ *   - node--promoted: Appears on nodes promoted to the front page.
+ *   - node--sticky: Appears on nodes ordered above other non-sticky nodes in
+ *     teaser listings.
+ *   - node--unpublished: Appears on unpublished nodes visible only to site
+ *     admins.
+ * - title_attributes: Same as attributes, except applied to the main title
+ *   tag that appears in the template.
+ * - content_attributes: Same as attributes, except applied to the main
+ *   content tag that appears in the template.
+ * - author_attributes: Same as attributes, except applied to the author of
+ *   the node tag that appears in the template.
+ * - title_prefix: Additional output populated by modules, intended to be
+ *   displayed in front of the main title tag that appears in the template.
+ * - title_suffix: Additional output populated by modules, intended to be
+ *   displayed after the main title tag that appears in the template.
+ * - view_mode: View mode; for example, "teaser" or "full".
+ * - teaser: Flag for the teaser state. Will be true if view_mode is 'teaser'.
+ * - page: Flag for the full page state. Will be true if view_mode is 'full'.
+ * - readmore: Flag for more state. Will be true if the teaser content of the
+ *   node cannot hold the main body content.
+ * - logged_in: Flag for authenticated user status. Will be true when the
+ *   current user is a logged-in member.
+ * - is_admin: Flag for admin user status. Will be true when the current user
+ *   is an administrator.
+ *
+ * @see template_preprocess_node()
+ *
+ * @todo Remove the id attribute (or make it a class), because if that gets
+ *   rendered twice on a page this is invalid CSS for example: two lists
+ *   in different view modes.
+ */
+#}
+
+{% set content_type = node.bundle %}
+
+{%
+  set classes = [
+    'lgd-card',
+    'lgd-card--' ~ content_type|clean_class,
+    'node',
+    'node--type-' ~ node.bundle|clean_class,
+    node.isPromoted() ? 'node--promoted',
+    node.isSticky() ? 'node--sticky',
+    not node.isPublished() ? 'node--unpublished',
+    view_mode ? 'node--view-mode-' ~ view_mode|clean_class,
+  ]
+%}
+
+{% if not localgov_base_remove_css %}
+  {{ attach_library('localgov_base/card') }}
+{% endif %}
+
+<article{{ attributes.addClass(classes).removeAttribute('role') }}>
+
+  {#
+    The event content type has a specific field set for its teaser so we
+    are adding that here specifically. Hopefully all other content types
+    will use the same `field_media_image` field.
+  #}
+  {% if node.field_media_image.value or node.localgov_event_image.value %}
+    <div class="lgd-card__image">
+      {{ content.field_media_image }}
+      {{ content.localgov_event_image }}
+    </div>
+  {% endif %}
+
+  <div{{ content_attributes.addClass('lgd-card__content', 'lgd-card__content--' ~ content_type|clean_class) }}>
+
+    {{ title_prefix }}
+    {% if label and not page %}
+      <h3{{ title_attributes }}>
+        <a href="{{ url }}" rel="bookmark">{{ label }}</a>
+      </h3>
+    {% endif %}
+    {{ title_suffix }}
+
+    {#
+      We render the full content variable here, so any new fields added
+      are visible.
+    #}
+    {{ content|without('field_media_image', 'localgov_event_image') }}
+  </div>
+
+</article>


### PR DESCRIPTION
Closes #568 

## What does this change?

1. Adds a template for cards - node--localgov-card.html.twig
2. Adds CSS for cards - currently sets cards to look the same as the 'Featured news' items at the top of newsrooms

---
Thanks to [Big Blue Door](https://www.bigbluedoor.net/) for sponsoring my time to work on this.