### PR TITLE
updates template/css so only the title becomes a link

### DIFF
--- a/css/base/variables.css
+++ b/css/base/variables.css
@@ -404,6 +404,8 @@ body {
   --banner-content-bg-color: var(--color-accent);
   --banner-content-text-color: var(--color-white);
   --banner-title-size: var(--font-size-larger);
+  --color-banner-title-link: var(--color-white);
+  --color-banner-title-link-hover: var(--color-white);
 
   /* Teaser View Mode */
   --teaser-image-with: 33%;

--- a/css/components/banner.css
+++ b/css/components/banner.css
@@ -22,11 +22,18 @@
   font-size: var(--banner-title-size);
 }
 
-.banner__link .field--name-localgov-title {
-  text-decoration: underline;
+.banner__link {
+  text-underline-offset: 5px;
+  text-decoration-thickness: 2px;
+  color: var(--color-banner-title-link);
 }
 
-.banner__link:focus .field--name-localgov-title,
-.banner__link:hover .field--name-localgov-title {
+.banner__link.banner__link:focus,
+.banner__link:hover {
   text-decoration: none;
+  color: var(--color-banner-title-link-hover);
+}
+.banner__link.banner__link:focus-visible {
+  outline-offset: 2px;
+  outline: 2px dashed var(--color-banner-title-link-hover);
 }

--- a/templates/paragraphs/paragraph--localgov-banner-primary.html.twig
+++ b/templates/paragraphs/paragraph--localgov-banner-primary.html.twig
@@ -42,7 +42,7 @@
 {%
   set classes = [
     'banner',
-    'banner--primary', 
+    'banner--primary',
     'paragraph',
     'paragraph--type--' ~ paragraph.bundle|clean_class,
     view_mode ? 'paragraph--view-mode--' ~ view_mode|clean_class,
@@ -64,13 +64,16 @@
       {{ content.localgov_image }}
     </div>
   {% endif %}
-  {% if banner_url %}
-    <a class="banner__link" href="{{ banner_url }}">
-  {% endif %}
-    <div class="banner__content">
-      {{ content|without('localgov_image', 'localgov_url') }}
-    </div>
-  {% if banner_url %}
-    </a>
-  {% endif %}
+  <div class="banner__content">
+    {% if banner_url %}
+      <a class="banner__link" href="{{ banner_url }}">
+    {% endif %}
+      {{ content.localgov_title }}
+    {% if banner_url %}
+      </a>
+    {% endif %}
+
+    {{ content|without('localgov_title', 'localgov_image', 'localgov_url') }}
+
+  </div>
 </div>


### PR DESCRIPTION
Relates to #661 

## What does this change?

Changes the template for the primary banner paragraph type so that if there is a link for the banner, only the title becomes a link rather than all the content.

~I'll create a corresponding PR to update the help text for the field so it doesn't say the whole banner will be linked.~
[Corresponding PR for LocalGov Paragraphs](https://github.com/localgovdrupal/localgov_paragraphs/pull/205)

## How to test

- Create a subsite
- Add a Primary Banner to it
- Give that banner a link
- Give it a title
- Give it a summary
- Check that only the banner title is linked rather than all the content in the banner

## Have we considered potential risks?

This might make some changes to existing sites, so we need to communicate that in the release notes.

---
Thanks to [Big Blue Door](https://www.bigbluedoor.net/) for sponsoring my time to work on this.