### PR TITLE
adds focus states for service statuses

### DIFF
--- a/css/components/service-statuses.css
+++ b/css/components/service-statuses.css
@@ -56,3 +56,34 @@
   border-color: var(--service-statuses-list-border-color);
   border-block-start: var(--service-statuses-list-border);
 }
+
+.service-status .nav-tabs .nav-item .nav-link.active .service-status-title {
+  background-color: var(--color-focus);
+}
+
+.service-status .card .card-header .status-accordion-header:hover,
+.service-status .card .card-header .status-accordion-header:focus,
+.service-status .nav-tabs .nav-item .nav-link .service-status-title:hover,
+.service-status .nav-tabs .nav-item .nav-link .service-status-title:focus,
+.service-status .nav-tabs .nav-item .nav-link:hover .service-status-title,
+.service-status .nav-tabs .nav-item .nav-link:focus .service-status-title {
+  background-color: var(--color-focus);
+}
+
+.service-status
+  .nav-tabs
+  .nav-item
+  .nav-link.active:hover
+  .service-status-title,
+.service-status
+  .nav-tabs
+  .nav-item
+  .nav-link.active:focus
+  .service-status-title {
+  text-decoration: underline;
+}
+
+.service-status .card .card-header a:focus-visible {
+  outline: 2px dashed var(--color-accent);
+  outline-offset: 3px;
+}

--- a/localgov_base.theme
+++ b/localgov_base.theme
@@ -222,6 +222,9 @@ function localgov_base_views_pre_render(ViewExecutable $view) {
   if ($view->storage->id() === 'localgov_sitewide_search') {
     $view->element['#attached']['library'][] = 'localgov_base/sitewide-search';
   }
+  if ($view->id() === 'service_status' && $view->current_display === 'service_status_page') {
+    $view->element['#attached']['library'][] = 'localgov_base/service-statuses';
+  }
 }
 
 /**


### PR DESCRIPTION
Closes #415 

## What does this change?

- Sets correct focus colour for focus states for Service Statuses
- Adds outline to focus items when on small screen

## How to test

- Visit https://localgov.ddev.site/service-status
- Check that we now have the correct yellow `var(--color-focus)` on the vertical tabs item when hovering/focusing
- Check that when on small screens and you tab to an accordion item, the title has a dashed outline.

---
Thanks to [Big Blue Door](https://www.bigbluedoor.net/) for sponsoring my time to work on this.