### PR TITLE
Adds toggle to use stacked header for guides

### DIFF
--- a/config/install/localgov_base.settings.yml
+++ b/config/install/localgov_base.settings.yml
@@ -2,4 +2,5 @@ localgov_base_remove_css: FALSE
 localgov_base_remove_js: FALSE
 localgov_base_add_unpublished_background_colour: TRUE
 localgov_base_add_draft_note_to_unpublished_content: FALSE
+localgov_base_guides_stacked_header: FALSE
 localgov_base_header_behaviour: 'default'

--- a/config/schema/localgov_base.schema.yml
+++ b/config/schema/localgov_base.schema.yml
@@ -14,6 +14,9 @@ localgov_base.settings:
     localgov_base_add_draft_note_to_unpublished_content:
       type: boolean
       label: 'Add "[Draft]" to title of unpublished content.'
+    localgov_base_guides_stacked_header:
+      type: boolean
+      label: 'Use stacked header for guides.'
     localgov_base_header_behaviour:
       type: string
       label: 'Header behaviour'

--- a/localgov_base.theme
+++ b/localgov_base.theme
@@ -53,6 +53,12 @@ function localgov_base_form_system_theme_settings_alter(&$form, FormStateInterfa
     '#default_value' => theme_get_setting('localgov_base_show_back_to_top_link'),
     '#description'   => t('This adds a link to the beginning of the page content (<code>#main-content</code>).'),
   ];
+  $form['localgov_base_guides_stacked_header'] = [
+    '#type'          => 'checkbox',
+    '#title'         => t('Use the stacked header pattern for guides.'),
+    '#default_value' => theme_get_setting('localgov_base_guides_stacked_header'),
+    '#description'   => t('This will mean that your guide title and subtitle will be grouped together in the header, following the approach used by the NHS design system.'),
+  ];
   $form['localgov_base_header_behaviour'] = [
     '#type' => 'radios',
     '#title' => t('Header behaviour'),


### PR DESCRIPTION
Closes #675 

## What does this change?

Adds a toggle on the theme settings page to allow people to set "Use stacked header" for guides.

If this is set, then we can use the `{{ subtitle }}` in the page header Twig file to use the stacked header pattern.

The only problem is, guides does not have a field for subtitle! So this is WIP until that happens.

---
Thanks to [Big Blue Door](https://www.bigbluedoor.net/) for sponsoring my time to work on this.