### PR TITLE
adds default content for 403 and 404 pages

### DIFF
--- a/localgov_base.theme
+++ b/localgov_base.theme
@@ -163,8 +163,8 @@ function localgov_base_preprocess_page(&$variables): void {
   if ($route === 'entity.node.canonical') {
     $node = $route_match->getParameter('node');
     $node_id = $node->id();
-    $is_404_page_node = 'node/' . $node_id === $site_404;
-    $is_403_page_node = 'node/' . $node_id === $site_403;
+    $is_404_page_node = $site_404 === 'node/' . $node_id;
+    $is_403_page_node = $site_403 === 'node/' . $node_id;
     if ($is_404_page_node && empty($site_404)) {
       $variables['default_status_content'] = true;
     } else {

--- a/localgov_base.theme
+++ b/localgov_base.theme
@@ -157,7 +157,7 @@ function localgov_base_preprocess_page(&$variables): void {
   // This is used to determine if we should show the default 403/404 content,
   // or if we should show the content of the node that is set as the 403/404
   // page.
-  $variables['default_status_content'] = true;
+  $variables['default_status_content'] = TRUE;
   $route_match = Drupal::routeMatch();
   $route = $route_match->getRouteName();
   if ($route === 'entity.node.canonical') {
@@ -166,14 +166,16 @@ function localgov_base_preprocess_page(&$variables): void {
     $is_404_page_node = $site_404 === 'node/' . $node_id;
     $is_403_page_node = $site_403 === 'node/' . $node_id;
     if ($is_404_page_node && empty($site_404)) {
-      $variables['default_status_content'] = true;
-    } else {
-      $variables['default_status_content'] = false;
+      $variables['default_status_content'] = TRUE;
+    }
+    else {
+      $variables['default_status_content'] = FALSE;
     }
     if ($is_403_page_node && empty($site_403)) {
-      $variables['default_status_content'] = true;
-    } else {
-      $variables['default_status_content'] = false;
+      $variables['default_status_content'] = TRUE;
+    }
+    else {
+      $variables['default_status_content'] = FALSE;
     }
   }
 

--- a/localgov_base.theme
+++ b/localgov_base.theme
@@ -146,6 +146,37 @@ function localgov_base_preprocess_page(&$variables): void {
   if (theme_get_setting('localgov_base_show_back_to_top_link')) {
     $variables['back_to_top'] = TRUE;
   }
+
+  // Load the site configuration.
+  $site_config = \Drupal::config('system.site');
+  $site_403 = $site_config->get('page.403');
+  $site_404 = $site_config->get('page.404');
+
+  // Custom 403 and 404 pages.
+  // We have a variable in page.html.twig called default_status_content.
+  // This is used to determine if we should show the default 403/404 content,
+  // or if we should show the content of the node that is set as the 403/404
+  // page.
+  $variables['default_status_content'] = true;
+  $route_match = Drupal::routeMatch();
+  $route = $route_match->getRouteName();
+  if ($route === 'entity.node.canonical') {
+    $node = $route_match->getParameter('node');
+    $node_id = $node->id();
+    $is_404_page_node = 'node/' . $node_id === $site_404;
+    $is_403_page_node = 'node/' . $node_id === $site_403;
+    if ($is_404_page_node && empty($site_404)) {
+      $variables['default_status_content'] = true;
+    } else {
+      $variables['default_status_content'] = false;
+    }
+    if ($is_403_page_node && empty($site_403)) {
+      $variables['default_status_content'] = true;
+    } else {
+      $variables['default_status_content'] = false;
+    }
+  }
+
 }
 
 /**

--- a/localgov_base.theme
+++ b/localgov_base.theme
@@ -165,13 +165,13 @@ function localgov_base_preprocess_page(&$variables): void {
     $node_id = $node->id();
     $is_404_page_node = $site_404 === 'node/' . $node_id;
     $is_403_page_node = $site_403 === 'node/' . $node_id;
-    if ($is_404_page_node && empty($site_404)) {
+    if ($is_404_page_node && is_null($site_404)) {
       $variables['default_status_content'] = TRUE;
     }
     else {
       $variables['default_status_content'] = FALSE;
     }
-    if ($is_403_page_node && empty($site_403)) {
+    if ($is_403_page_node && is_null($site_403)) {
       $variables['default_status_content'] = TRUE;
     }
     else {

--- a/templates/layout/status-pages/page--403.html.twig
+++ b/templates/layout/status-pages/page--403.html.twig
@@ -2,7 +2,7 @@
 	{% set default_status_content %}
 	  <p>{{ "Sorry, you do not have access to this page"|t }}</p>
     {% trans %}
-      <p>Perhaps you need to <a href="/user/login">login</a> to the site.</p>
+      <p>Perhaps you need to <a href="/user/login">log in</a> to the site.</p>
     {% endtrans %}
 	{% endset %}
 {% endif %}

--- a/templates/layout/status-pages/page--403.html.twig
+++ b/templates/layout/status-pages/page--403.html.twig
@@ -1,1 +1,10 @@
+{% if default_status_content %}
+	{% set default_status_content %}
+	  <p>{{ "Sorry, you do not have access to this page"|t }}</p>
+    {% trans %}
+      <p>Perhaps you need to <a href="/user/login">login</a> to the site.</p>
+    {% endtrans %}
+	{% endset %}
+{% endif %}
+
 {% extends "@localgov_base/layout/status-pages/page-status.html.twig" %}

--- a/templates/layout/status-pages/page--404.html.twig
+++ b/templates/layout/status-pages/page--404.html.twig
@@ -1,1 +1,10 @@
+{% if default_status_content %}
+	{% set default_status_content %}
+	  <p>{{ "We couldn't find the page you're looking for. It's possible you entered the address incorrectly or you're looking for a page we've moved or deleted."|t }}</p>
+	  <p>{{ "If you typed the web address, check it is correct."|t }}</p>
+	  <p>{{ "If you pasted the web address, check you copied the entire address."|t }}</p>
+	  <p>{{ "You can browse from the homepage or use the search box above to find the information you need."|t }}</p>
+	{% endset %}
+{% endif %}
+
 {% extends "@localgov_base/layout/status-pages/page-status.html.twig" %}

--- a/templates/layout/status-pages/page-status.html.twig
+++ b/templates/layout/status-pages/page-status.html.twig
@@ -113,6 +113,7 @@
         <div class="lgd-row">
           <div class="lgd-row__full">
             <div class="padding-horizontal">
+              {{ default_status_content }}
               {{ page.content }}
             </div>
           </div>


### PR DESCRIPTION
Closes #698 

## What does this change?

1. Adds a variable in page-status.html.twig for "default_status_content"
2. We use this variable in the page--403/page--404.html.twig file to set a nice default message for these pages
3. When then check to see if a custom 403/404 page has been set (as a node) and if so, we set the new variable to false and use the content from the node

## How to test

- Check by default we now have better 403/404 content.
- Then set custom nodes as the default for 403/404
- Check that the template content is overridden
