### PR TITLE
Fix/1.x/705 lgd icon doesnt use theme variable

### DIFF
--- a/components/icon/icon.component.yml
+++ b/components/icon/icon.component.yml
@@ -29,3 +29,10 @@ props:
       description: >
         A space-separated string of one or more icon classes to be added to the
         defaults.
+    theme:
+      type: string
+      title: Theme
+      description: >
+        The machine name of the theme containing the icon path. Defaults to
+        'localgov_base', but will be ignored if icon_path already begins
+        with '@'.

--- a/components/icon/icon.twig
+++ b/components/icon/icon.twig
@@ -35,6 +35,10 @@
 {% set theme = theme|default('localgov_base') %}
 {% set icon_wrapper_element = icon_wrapper_element|default('div') %}
 
+{%- set icon_fullpath -%}
+  {% if icon_path|first != '@' %}@{{ theme }}/{% endif %}{{ icon_path }}/{{ icon_name }}.svg
+{%- endset -%}
+
 {% set attributes = create_attribute()
   .setAttribute('aria-hidden', decoration|default('true'))
   .addClass('lgd-icon')
@@ -42,5 +46,5 @@
 %}
 
 <{{ icon_wrapper_element }}{{ attributes }}>
-  {% include icon_path ~ '/' ~ icon_name ~ '.svg' %}
+  {% include icon_fullpath %}
 </{{ icon_wrapper_element }}>

--- a/components/icon/icon.twig
+++ b/components/icon/icon.twig
@@ -36,7 +36,7 @@
 {% set icon_wrapper_element = icon_wrapper_element|default('div') %}
 
 {%- set icon_fullpath -%}
-  {% if icon_path|first != '@' %}@{{ theme }}/{% endif %}{{ icon_path }}/{{ icon_name }}.svg
+  {% if icon_path|first != '@' %}@{{ theme }}/{% endif %}{{ icon_path|default('includes/icons') }}/{{ icon_name }}.svg
 {%- endset -%}
 
 {% set attributes = create_attribute()

--- a/components/icon/icon.twig
+++ b/components/icon/icon.twig
@@ -35,10 +35,6 @@
 {% set theme = theme|default('localgov_base') %}
 {% set icon_wrapper_element = icon_wrapper_element|default('div') %}
 
-{%- set icon_fullpath -%}
-  {% if icon_path|first != '@' %}@{{ theme }}/{% endif %}{{ icon_path|default('includes/icons') }}/{{ icon_name }}.svg
-{%- endset -%}
-
 {% set attributes = create_attribute()
   .setAttribute('aria-hidden', decoration|default('true'))
   .addClass('lgd-icon')
@@ -46,5 +42,5 @@
 %}
 
 <{{ icon_wrapper_element }}{{ attributes }}>
-  {% include icon_fullpath %}
+  {% if icon_path|first != '@' %}@{{ theme }}/{% endif %}{{ icon_path|default('includes/icons') }}/{{ icon_name }}.svg
 </{{ icon_wrapper_element }}>


### PR DESCRIPTION
Closes #705

## What does this change?

The PR adds the following to `localgov_base:icon`:

1. use the `theme` variable to namespace the path to the icon file if `icon_path` does not begin with `@`,
2. document that the `theme` variable exists in `icon.component.yml` (it was already documented in code),
3. adds a `|default('includes/icons')` to the `icon_path` variable to make the SDC behave as described in comments

## How to test

1. create a child theme, `lgdtest`,
2. add an icon like `web/themes/custom/lgdtest/assets/icons/someIcon.svg` (preferably different from any icon in `localgov_base`),
4. include the `localgov_base:icon` component in the new child theme in _each_ of the following ways: 
    ```twig
    {# Test icon from another theme, using 'theme' var #}
    {% include 'localgov_base:icon' with {
      theme: 'lgdtest',
      icon_path: 'assets/icons',
      icon_name: 'someIcon',
    } %}
    
    {# Test icon from another theme, namespacing 'icon_path' var (note: `theme` var will be ignored) #}
    {% include 'localgov_base:icon' with {
      theme: 'lgdtest',
      icon_path: '@lgdtest/assets/icons',
      icon_name: 'someIcon',
    } %}
    
    {# Test icon from localgov_base, using 'theme' var #}
    {% include 'localgov_base:icon' with {
      theme: 'localgov_base',
      icon_name: 'arrow-down',
    } %}
    
    {# Test icon from localgov_base, namespacing 'icon_path' var (note: `theme` var will be ignored) #}
    {% include 'localgov_base:icon' with {
      theme: 'localgov_base',
      icon_path: '@localgov_base/includes/icons',
      icon_name: 'arrow-down',
    } %}
    
    {# Test icon from localgov_base, using *only* icon_name var #}
    {% include 'localgov_base:icon' with {
      icon_name: 'arrow-down',
    } %}
    ```
5. verify that the expected icons _all_ appear.

## How can we measure success?

- check that _existing_ consumers of `localgov_base:icon` (i.e. [`localgov_base:prev-next`](https://github.com/localgovdrupal/localgov_base/tree/1.x/components/prev-next))work as expected
- verify all the anticipated modes (above) render correctly
- this _should_ leave existing implementations untouched

## Have we considered potential risks?

- the potential risks are wsod on templates making use of the `localgov_base:icon` SDC, so testing matters :)

## Images

n/a

## Accessibility

n/a