### PR TITLE
adds spacing between items aligned via wysiwyg

### DIFF
--- a/css/base/variables.css
+++ b/css/base/variables.css
@@ -435,6 +435,7 @@ body {
   --btn-start-icon-size: var(--font-size-largest);
   --btn-start-icon-top: -3px;
   --external-link-icon-color: var(--color-accent);
+  --wysiwyg-align-spacing: var(--spacing);
 
   /* Alert Banner */
   --alert-banner-bg-color: var(--color-success);

--- a/css/components/wysiwyg-styles.css
+++ b/css/components/wysiwyg-styles.css
@@ -75,3 +75,11 @@
   content: "\2714\0020";
   color: var(--color-green);
 }
+
+.align-left {
+  margin-right: var(--wysiwyg-align-spacing);
+}
+
+.align-right {
+  margin-left: var(--wysiwyg-align-spacing);
+}


### PR DESCRIPTION
Closes #712 

## What does this change?

If something (an image for example) is aligned left/right via the wysiwyg, this will add some space between it and the text.

## To test

You might need to configure the text input for page page to move the "Align images" item to below the "Limit allowed HTML tags and correct faulty HTML" item - so it's at the same level as "Embed media", or else the float left/right will be stripped out. For details see: https://github.com/localgovdrupal/localgov_core/issues/272