### PR TITLE
chore: drop compatibility layer now 10.3 is minimum support version

### DIFF
--- a/localgov_base.theme
+++ b/localgov_base.theme
@@ -135,12 +135,7 @@ function localgov_base_preprocess_page(&$variables): void {
 
     /** @var \Drupal\Core\Render\RendererInterface $renderer */
     $renderer = \Drupal::service('renderer');
-    $rendered = DeprecationHelper::backwardsCompatibleCall(
-      currentVersion: \Drupal::VERSION,
-      deprecatedVersion: '10.3',
-      currentCallable: fn() => $renderer->renderInIsolation($copy),
-      deprecatedCallable: fn() => $renderer->renderPlain($copy),
-    );
+    $rendered = $renderer->renderInIsolation($copy);
 
     $variables['has_' . $region] = strlen(trim(strip_tags($rendered, '<drupal-render-placeholder><embed><hr><iframe><img><input><link><object><script><source><style><video>'))) > 0;
   }

--- a/localgov_base.theme
+++ b/localgov_base.theme
@@ -6,7 +6,6 @@
  */
 
 use Drupal\Component\Utility\Crypt;
-use Drupal\Component\Utility\DeprecationHelper;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Url;
 use Drupal\views\ViewExecutable;


### PR DESCRIPTION
<!-- See https://docs.localgovdrupal.org/contributing/ for guidelines on contributing. -->

## What does this change?

Some housekeeping now that 10.3 is the minimum supported Drupal core, so we no longer need this backwards compatible layer.