### PR TITLE
allowing ID randomization but keeping the stable selector

### DIFF
--- a/localgov_base.theme
+++ b/localgov_base.theme
@@ -301,19 +301,23 @@ function localgov_base_views_pre_render(ViewExecutable $view): void {
 /**
  * Implements hook_preprocess_container().
  */
-function localgov_base_preprocess_container(&$variables): void {
-
-  // Randomize form container IDs for accessibility.
+ function localgov_base_preprocess_container(&$variables): void {
   // See https://www.drupal.org/project/drupal/issues/1852090
+  // Ensure the container has an ID.
   if (isset($variables['element']['#id'])) {
-    $id = $variables['element']['#id'];
-    if ($id === 'edit-actions') {
-      $id .= '--' . Crypt::randomBytesBase64(8);
+    $original_id = $variables['element']['#id'];
+
+    // Only modify 'edit-actions' to prevent affecting other elements.
+    if ($original_id === 'edit-actions') {
+      $random_suffix = Crypt::randomBytesBase64(8);
+      $random_id = $original_id . '--' . $random_suffix;
+
+      // Keep a stable selector but allow ID randomization.
+      $variables['attributes']['id'] = $random_id;
+      $variables['attributes']['data-drupal-selector'] = $original_id;
+      $variables['element']['#attributes']['data-drupal-selector'] = $original_id;
+      $variables['element']['#id'] = $random_id;
     }
-    $variables['attributes']['id'] = $id;
-    $variables['attributes']['data-drupal-selector'] = $id;
-    $variables['element']['#attributes']['data-drupal-selector'] = $id;
-    $variables['element']['#id'] = $id;
   }
 }
 


### PR DESCRIPTION
<!-- See https://docs.localgovdrupal.org/contributing/ for guidelines on contributing. -->

## What does this change?

This PR addresses an issue related to form container ID randomization for improved accessibility and Address Dropdown not populating the addresses at drupal Form. Previously, the localgov_base_preprocess_container() function was appending a random suffix to the edit-actions form container ID. This introduced potential issues with JavaScript selectors that rely on the #edit-actions ID, as they were no longer able to target the element due to the dynamic nature of the ID.

**This change ensures that:**

1. The ID is randomized for accessibility, but we still maintain a stable selector (data-drupal-selector) to be used by JavaScript.
2. JavaScript selectors that depend on the original ID (edit-actions) will work as expected, avoiding potential breakage in behavior.
3. The random ID is applied to the id attribute, but the original ID is retained as data-drupal-selector for stable targeting.

## How to test

Check the edit-actions form container element:

On the main branch, inspect the container and check the id attribute. It should be static (e.g., #edit-actions).
On this branch, inspect the same container and verify that the id has been randomized (e.g., #edit-actions--<random>) but the data-drupal-selector remains as edit-actions.

## How can we measure success?

1. No errors or broken JavaScript functionality related to the #edit-actions container ID after the change.
2. JavaScript selectors that use data-drupal-selector="edit-actions" work as expected. 
3. Improved accessibility with randomized form container IDs while keeping the stable selector intact.

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error
require an alarm? Should user help, infosec, or legal be informed of this
change? Is private information guarded? Do we need to add anything in the
backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and
what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)