### PR TITLE
Move restricted_width_content_types to .theme file

### DIFF
--- a/localgov_base.theme
+++ b/localgov_base.theme
@@ -197,7 +197,7 @@ function localgov_base_preprocess_page(&$variables): void {
  * @return array
  *   An array of restricted width content types.
  */
-function _get_restricted_width_content_types() {
+function _localgov_get_restricted_width_content_types() {
   return [
     'localgov_services_page',
     'localgov_event',
@@ -219,7 +219,7 @@ function localgov_base_preprocess_node(&$variables): void {
     // some content types. This is helpful to reduce the line-length for
     // better readability.
     $variables['restricted_width_content_types'] = [];
-    if (in_array($node->bundle(), _get_restricted_width_content_types())) {
+    if (in_array($node->bundle(), _localgov_get_restricted_width_content_types())) {
       $variables['restricted_width_content_types'][] = $node->bundle();
     }
 

--- a/localgov_base.theme
+++ b/localgov_base.theme
@@ -203,7 +203,7 @@ function _localgov_get_restricted_width_content_types() {
     'localgov_event',
     'localgov_services_status',
     'localgov_step_by_step_overview',
-    'localgov_publication_cover_page',
+    'localgov_publication_cover_page'
   ];
 }
 
@@ -219,7 +219,7 @@ function localgov_base_preprocess_node(&$variables): void {
     // some content types. This is helpful to reduce the line-length for
     // better readability.
     $variables['restricted_width_content_types'] = [];
-    if (in_array($node->bundle(), _localgov_get_restricted_width_content_types())) {
+    if (in_array($node->bundle(), _localgov_get_restricted_width_content_types(), TRUE)) {
       $variables['restricted_width_content_types'][] = $node->bundle();
     }
 

--- a/localgov_base.theme
+++ b/localgov_base.theme
@@ -191,10 +191,39 @@ function localgov_base_preprocess_page(&$variables): void {
 }
 
 /**
+ * Get the restricted width content types.
+ *
+ * @return array
+ *   An array of restricted width content types.
+ */
+function _get_restricted_width_content_types() {
+  return [
+    'localgov_services_page',
+    'localgov_event',
+    'localgov_services_status',
+    'localgov_step_by_step_overview',
+    'localgov_publication_cover_page',
+  ];
+}
+
+/**
  * Implements hook_preprocess_HOOK().
  */
 function localgov_base_preprocess_node(&$variables): void {
+  $node = $variables['node'];
   $node_status = $variables['node']->isPublished();
+
+  if ($node instanceof \Drupal\node\NodeInterface && $variables['view_mode'] === 'full') {
+    // Restrict width of the content area to two-thirds of the screen for
+    // some content types. This is helpful to reduce the line-length for
+    // better readability.
+    $variables['restricted_width_content_types'] = [];
+    if (in_array($node->bundle(), _get_restricted_width_content_types())) {
+      $variables['restricted_width_content_types'][] = $node->bundle();
+    }
+
+  }
+
   if ($node_status === FALSE) {
     if (theme_get_setting('localgov_base_add_draft_note_to_unpublished_content') === TRUE) {
       $variables['label'] = t('[Draft]') . " " . $variables['node']->label();

--- a/localgov_base.theme
+++ b/localgov_base.theme
@@ -8,6 +8,7 @@
 use Drupal\Component\Utility\Crypt;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Url;
+use Drupal\Node\NodeInterface;
 use Drupal\views\ViewExecutable;
 
 /**
@@ -213,7 +214,7 @@ function localgov_base_preprocess_node(&$variables): void {
   $node = $variables['node'];
   $node_status = $variables['node']->isPublished();
 
-  if ($node instanceof \Drupal\node\NodeInterface && $variables['view_mode'] === 'full') {
+  if ($node instanceof NodeInterface && $variables['view_mode'] === 'full') {
     // Restrict width of the content area to two-thirds of the screen for
     // some content types. This is helpful to reduce the line-length for
     // better readability.

--- a/templates/content/node--full.html.twig
+++ b/templates/content/node--full.html.twig
@@ -71,26 +71,12 @@
  */
 #}
 
-{# 
-  Restrict width of the content area to two-thirds of the screen for 
-  some content types. This is helpful to reduce the line-length for 
-  better readability.
-#}
-{% set restricted_width_content_types = [
-    'localgov_services_page',
-    'localgov_event',
-    'localgov_step_by_step_overview',
-    'localgov_services_status',
-    'localgov_publication_cover_page'
-  ] 
-%}
-
 {% set content_type = node.bundle %}
 
 {% if not localgov_base_remove_css %}
   {{ attach_library('localgov_base/full') }}
-  {% if content_type == 'localgov_directories_venue' 
-        or content_type == 'localgov_directories_page' 
+  {% if content_type == 'localgov_directories_venue'
+        or content_type == 'localgov_directories_page'
         or content_type == 'localgov_directory' %}
     {{ attach_library('localgov_base/directories') }}
   {% endif %}
@@ -127,7 +113,7 @@
         <a href="{{ url }}" rel="bookmark">{{ label }}</a>
       </h2>
     {% endif %}
-    {{ title_suffix }}  
+    {{ title_suffix }}
 
     {% if display_submitted %}
       <footer class="node__meta">
@@ -137,11 +123,11 @@
           {{ metadata }}
         </div>
       </footer>
-    {% endif %} 
+    {% endif %}
 
     {% if content_type in restricted_width_content_types %}
       <div class="node__restricted-width-section">
-    {% endif %} 
+    {% endif %}
 
       <div{{ content_attributes.addClass(content_type|clean_class ~ '__content', 'node__content') }}>
         {{ content|without('localgov_subsites_content') }}
@@ -151,7 +137,7 @@
   {% if node.localgov_subsites_content.value or content.localgov_subsites_content['#type'] == 'layout_paragraphs_builder' %}
     {{ content.localgov_subsites_content }}
   {% endif %}
-  
+
 
   {% if content_type in restricted_width_content_types %}
     </div>


### PR DESCRIPTION
Closes #733 

## What does this change?
Moves the declaration of the `restricted_widths_content_types` from `node--full.html.twig` to `localgov_base.theme` so it's easier for subthemes to add to/remove from the array.

