### PR TITLE
Extend preprocess block/node to recognise both draft and archived states

### DIFF
--- a/config/install/localgov_base.settings.yml
+++ b/config/install/localgov_base.settings.yml
@@ -2,6 +2,7 @@ localgov_base_remove_css: FALSE
 localgov_base_remove_js: FALSE
 localgov_base_add_unpublished_background_colour: TRUE
 localgov_base_add_draft_note_to_unpublished_content: FALSE
+localgov_base_add_archived_note_to_archived_content: FALSE
 localgov_base_header_behaviour: 'default'
 localgov_base_localgov_guides_stacked_heading: FALSE
 localgov_base_localgov_guides_vertical_navigation: TRUE

--- a/config/schema/localgov_base.schema.yml
+++ b/config/schema/localgov_base.schema.yml
@@ -14,6 +14,9 @@ localgov_base.settings:
     localgov_base_add_draft_note_to_unpublished_content:
       type: boolean
       label: 'Add "[Draft]" to title of unpublished content.'
+    localgov_base_add_archived_note_to_archived_content:
+      type: boolean
+      label: 'Add "[Archived]" to title of archived content.'
     localgov_base_header_behaviour:
       type: string
       label: 'Header behaviour'

--- a/localgov_base.theme
+++ b/localgov_base.theme
@@ -201,9 +201,15 @@ function localgov_base_preprocess_node(&$variables): void {
       if ($state == 'draft') {
         $variables['label'] = t('[Draft]') . " " . $variables['node']->label();
       }
-      elseif ($state == 'archived') {
-        $variables['label'] = t('[Archived]') . " " . $variables['node']->label();
-      }
+    }
+  }
+  // We have a theme setting to prepend 'archived' to the title of
+  // archived content, but we don't mind whether it is published or not.
+  // An archived state does not have to always be unpubilshed.
+  if (theme_get_setting('localgov_base_add_archived_note_to_archived_content') === TRUE) {
+    $state = $variables['node']->get('moderation_state')->getString();
+    if ($state == 'archived') {
+      $variables['label'] = t('[Archived]') . " " . $variables['node']->label();
     }
   }
 
@@ -230,14 +236,21 @@ function localgov_base_preprocess_block(&$variables): void {
       if ($node_status === FALSE) {
         if (theme_get_setting('localgov_base_add_draft_note_to_unpublished_content') === TRUE) {
           $current_title = $variables['content'][0]['#title'];
-          $variables['content'][0]['#title'] = t('[Draft]') . " " . $current_title;
           $state = $node->get('moderation_state')->getString();
           if ($state == 'draft') {
             $variables['content'][0]['#title'] = t('[Draft]') . " " . $current_title;
           }
-          elseif ($state == 'archived') {
-            $variables['content'][0]['#title'] = t('[Archived]') . " " . $current_title;
-          }
+        }
+      }
+
+      // We have a theme setting to prepend 'archived' to the title of
+      // archived content, but we don't mind whether it is published or not.
+      // An archived state does not have to always be unpubilshed.
+      if (theme_get_setting('localgov_base_add_archived_note_to_archived_content') === TRUE) {
+        $current_title = $variables['content'][0]['#title'];
+        $state = $node->get('moderation_state')->getString();
+        if ($state == 'archived') {
+          $variables['content'][0]['#title'] = t('[Archived]') . " " . $current_title;
         }
       }
 

--- a/localgov_base.theme
+++ b/localgov_base.theme
@@ -196,7 +196,7 @@ function localgov_base_preprocess_page(&$variables): void {
 function localgov_base_preprocess_node(&$variables): void {
   $node_status = $variables['node']->isPublished();
   if ($node_status === FALSE) {
-    if (theme_get_setting('localgov_base_add_draft_note_to_unpublished_content') == TRUE) {
+    if (theme_get_setting('localgov_base_add_draft_note_to_unpublished_content') === TRUE) {
       $state = $variables['node']->get('moderation_state')->getString();
       if ($state == 'draft') {
         $variables['label'] = t('[Draft]') . " " . $variables['node']->label();

--- a/localgov_base.theme
+++ b/localgov_base.theme
@@ -196,8 +196,14 @@ function localgov_base_preprocess_page(&$variables): void {
 function localgov_base_preprocess_node(&$variables): void {
   $node_status = $variables['node']->isPublished();
   if ($node_status === FALSE) {
-    if (theme_get_setting('localgov_base_add_draft_note_to_unpublished_content') === TRUE) {
-      $variables['label'] = t('[Draft]') . " " . $variables['node']->label();
+    if (theme_get_setting('localgov_base_add_draft_note_to_unpublished_content') == TRUE) {
+      $state = $variables['node']->get('moderation_state')->getString();
+      if ($state == 'draft') {
+        $variables['label'] = t('[Draft]') . " " . $variables['node']->label();
+      }
+      elseif ($state == 'archived') {
+        $variables['label'] = t('[Archived]') . " " . $variables['node']->label();
+      }
     }
   }
 
@@ -225,6 +231,13 @@ function localgov_base_preprocess_block(&$variables): void {
         if (theme_get_setting('localgov_base_add_draft_note_to_unpublished_content') === TRUE) {
           $current_title = $variables['content'][0]['#title'];
           $variables['content'][0]['#title'] = t('[Draft]') . " " . $current_title;
+          $state = $node->get('moderation_state')->getString();
+          if ($state == 'draft') {
+            $variables['content'][0]['#title'] = t('[Draft]') . " " . $current_title;
+          }
+          elseif ($state == 'archived') {
+            $variables['content'][0]['#title'] = t('[Archived]') . " " . $current_title;
+          }
         }
       }
 

--- a/localgov_base.theme
+++ b/localgov_base.theme
@@ -42,9 +42,16 @@ function localgov_base_form_system_theme_settings_alter(&$form, FormStateInterfa
 
   $form['localgov_base_add_draft_note_to_unpublished_content'] = [
     '#type'          => 'checkbox',
-    '#title'         => t('Add "Draft" to title of unpublished content.'),
+    '#title'         => t('Add "Draft" to title of draft unpublished content.'),
     '#default_value' => theme_get_setting('localgov_base_add_draft_note_to_unpublished_content'),
-    '#description'   => t('This adds the word "Draft" to the title of any unpublished content. This is useful if you have removed the pink background from unpublished content.'),
+    '#description'   => t('This adds the word "Draft" to the title of any draft unpublished content. This is useful if you have removed the pink background from unpublished content.'),
+  ];
+
+  $form['localgov_base_add_archived_note_to_archived_content'] = [
+    '#type'          => 'checkbox',
+    '#title'         => t('Add "Archived" to title of archived content.'),
+    '#default_value' => theme_get_setting('localgov_base_add_archived_note_to_archived_content'),
+    '#description'   => t('This adds the word "Archived" to the title of any content with the "archived" moderation state.'),
   ];
 
   $form['localgov_base_show_back_to_top_link'] = [


### PR DESCRIPTION

## What does this change?

Currently, you can optionally turn on a thing which will prepend `[draft]` to a node title, both in preprocess_node and preprocess_block. This change recognises moderation states so it will also label an archived node as archived.

## How to test

1. turn on the 'draft label' setting in theme settings
2. Unpublish a node. See that it says '[draft]' before the node title
3. Publish the node. See that the prepended label is gone.
4. Archive the node. See that it now says '[Archived]' before the node title

## How can we measure success?

Not sure about that.

## Have we considered potential risks?

It assumes moderation states exist, so I guess the risk would be if someone turns off Workflow then it would break. The workaround would be to turn off the feature in theme settings.


