### PR TITLE
Add theme setting for JS breakpoint

### DIFF
--- a/config/install/localgov_base.settings.yml
+++ b/config/install/localgov_base.settings.yml
@@ -6,3 +6,4 @@ localgov_base_add_archived_note_to_archived_content: FALSE
 localgov_base_header_behaviour: 'default'
 localgov_base_localgov_guides_stacked_heading: FALSE
 localgov_base_localgov_guides_vertical_navigation: TRUE
+localgov_base_mobile_breakpoint_js: '768'

--- a/config/schema/localgov_base.schema.yml
+++ b/config/schema/localgov_base.schema.yml
@@ -31,3 +31,8 @@ localgov_base.settings:
       type: boolean
       label: 'Vertical navigation'
       description: 'Choose whether the navigation should be vertical or not.'
+    localgov_base_mobile_breakpoint_js:
+      type: string
+      label: 'Mobile breakpoint for JS'
+      description: 'The mobile breakpoint for JS. This is used to determine when to apply mobile styles.'
+      default_value: '768'

--- a/js/header.js
+++ b/js/header.js
@@ -2,9 +2,18 @@
  * @file JS file for the header component.
  */
 
-(function headerScript(Drupal) {
+(function headerScript(Drupal, drupalSettings, once) {
   Drupal.behaviors.header = {
     attach(context) {
+      let mobileBreakpointJS = 768;
+      // If there is a drupalSettings variable for the breakpoint, use that.
+      if (
+        drupalSettings.localgov_base &&
+        drupalSettings.localgov_base.mobileBreakpointJS
+      ) {
+        mobileBreakpointJS = drupalSettings.localgov_base.mobileBreakpointJS;
+      }
+
       // Hide the search form label. We use .once() to avoid re-running.
       //
       // @todo: make it possible to override this without having to maintain a
@@ -167,7 +176,7 @@
       function handleWindowResized() {
         handleReset();
 
-        if (window.innerWidth < 768) {
+        if (window.innerWidth < mobileBreakpointJS) {
           if (
             Object.keys(navInfo).includes('secondary') &&
             navInfo.secondary.toggle
@@ -244,4 +253,4 @@
       );
     },
   };
-})(Drupal);
+})(Drupal, drupalSettings, once);

--- a/js/header.js
+++ b/js/header.js
@@ -5,25 +5,7 @@
 (function headerScript(Drupal, drupalSettings, once) {
   Drupal.behaviors.header = {
     attach(context) {
-      let mobileBreakpointJS = 768;
-      // If there is a drupalSettings variable for the breakpoint, use that.
-      if (
-        drupalSettings.localgov_base &&
-        drupalSettings.localgov_base.mobileBreakpointJS
-      ) {
-        let mobileBreakpoint = drupalSettings.localgov_base.mobileBreakpointJS;
-
-        // 1. If it has 'px' at the end, remove it.
-        mobileBreakpoint = mobileBreakpoint.replace('px', '');
-
-        // 2. Convert it to a number.
-        mobileBreakpoint = parseInt(mobileBreakpoint, 10);
-
-        // 3. Check that the value is greater than 0.
-        if (mobileBreakpoint > 0) {
-          mobileBreakpointJS = mobileBreakpoint;
-        }
-      }
+      const mobileBreakpointJS = drupalSettings.localgov_base.mobileBreakpointJS;
 
       // Hide the search form label. We use .once() to avoid re-running.
       //

--- a/js/header.js
+++ b/js/header.js
@@ -11,7 +11,18 @@
         drupalSettings.localgov_base &&
         drupalSettings.localgov_base.mobileBreakpointJS
       ) {
-        mobileBreakpointJS = drupalSettings.localgov_base.mobileBreakpointJS;
+        let mobileBreakpoint = drupalSettings.localgov_base.mobileBreakpointJS;
+
+        // 1. If it has 'px' at the end, remove it.
+        mobileBreakpoint = mobileBreakpoint.replace('px', '');
+
+        // 2. Convert it to a number.
+        mobileBreakpoint = parseInt(mobileBreakpoint, 10);
+
+        // 3. Check that the value is greater than 0.
+        if (mobileBreakpoint > 0) {
+          mobileBreakpointJS = mobileBreakpoint;
+        }
       }
 
       // Hide the search form label. We use .once() to avoid re-running.

--- a/js/subsites-menu.js
+++ b/js/subsites-menu.js
@@ -9,6 +9,15 @@
       // was actually resized.
       let windowWidth = window.innerWidth;
 
+      let mobileBreakpointJS = 768;
+      // If there is a drupalSettings variable for the breakpoint, use that.
+      if (
+        drupalSettings.localgov_base &&
+        drupalSettings.localgov_base.mobileBreakpointJS
+      ) {
+        mobileBreakpointJS = drupalSettings.localgov_base.mobileBreakpointJS;
+      }
+
       const subsitesMenuToggle = document.querySelector(
         '.subsite-extra__header-toggle-button',
       );
@@ -29,14 +38,15 @@
         subsitesMenu.classList.remove('subsite-extra-menu--active');
       }
 
-      // If the window is resized to more than 768px, reset the menu.
+      // If the window is resized to more than mobileBreakpointJS/768px,
+      // reset the menu.
       function handleWindowResized() {
         if (window.innerWidth === windowWidth) {
           return;
         }
         windowWidth = window.innerWidth;
 
-        if (windowWidth > 768) {
+        if (windowWidth > mobileBreakpointJS) {
           handleReset();
         }
       }

--- a/js/subsites-menu.js
+++ b/js/subsites-menu.js
@@ -9,25 +9,7 @@
       // was actually resized.
       let windowWidth = window.innerWidth;
 
-      let mobileBreakpointJS = 768;
-      // If there is a drupalSettings variable for the breakpoint, use that.
-      if (
-        drupalSettings.localgov_base &&
-        drupalSettings.localgov_base.mobileBreakpointJS
-      ) {
-        let mobileBreakpoint = drupalSettings.localgov_base.mobileBreakpointJS;
-
-        // 1. If it has 'px' at the end, remove it.
-        mobileBreakpoint = mobileBreakpoint.replace('px', '');
-
-        // 2. Convert it to a number.
-        mobileBreakpoint = parseInt(mobileBreakpoint, 10);
-
-        // 3. Check that the value is greater than 0.
-        if (mobileBreakpoint > 0) {
-          mobileBreakpointJS = mobileBreakpoint;
-        }
-      }
+      const mobileBreakpointJS = drupalSettings.localgov_base.mobileBreakpointJS;
 
       const subsitesMenuToggle = document.querySelector(
         '.subsite-extra__header-toggle-button',

--- a/js/subsites-menu.js
+++ b/js/subsites-menu.js
@@ -15,7 +15,18 @@
         drupalSettings.localgov_base &&
         drupalSettings.localgov_base.mobileBreakpointJS
       ) {
-        mobileBreakpointJS = drupalSettings.localgov_base.mobileBreakpointJS;
+        let mobileBreakpoint = drupalSettings.localgov_base.mobileBreakpointJS;
+
+        // 1. If it has 'px' at the end, remove it.
+        mobileBreakpoint = mobileBreakpoint.replace('px', '');
+
+        // 2. Convert it to a number.
+        mobileBreakpoint = parseInt(mobileBreakpoint, 10);
+
+        // 3. Check that the value is greater than 0.
+        if (mobileBreakpoint > 0) {
+          mobileBreakpointJS = mobileBreakpoint;
+        }
       }
 
       const subsitesMenuToggle = document.querySelector(

--- a/localgov_base.theme
+++ b/localgov_base.theme
@@ -87,12 +87,29 @@ function localgov_base_form_system_theme_settings_alter(&$form, FormStateInterfa
     '#default_value' => theme_get_setting('localgov_base_localgov_guides_vertical_navigation'),
     '#description'   => t('This will display the guide navigation vertically above the guide.'),
   ];
+
+  $form['localgov_base_mobile_breakpoint_js'] = [
+    '#type'          => 'textfield',
+    '#title'         => t('Mobile breakpoint for JavaScript'),
+    '#default_value' => theme_get_setting('localgov_base_mobile_breakpoint_js'),
+    '#description'   => t('This is the mobile breakpoint in pixels. This is used by the JS to determine when to show the mobile menu. If left blank, this will default to 768px.'),
+    '#attributes' => [
+      'placeholder' => '768',
+    ],
+
+  ];
 }
 
 /**
  * Implements hook_preprocess_html().
  */
 function localgov_base_preprocess_html(&$variables): void {
+  // Add the mobile breakpoint value to drupalSettings for use in JavaScript.
+  if (!empty(theme_get_setting('localgov_base_mobile_breakpoint_js'))) {
+    $mobile_breakpoint = theme_get_setting('localgov_base_mobile_breakpoint_js');
+    $variables['#attached']['drupalSettings']['localgov_base']['mobileBreakpointJS'] = $mobile_breakpoint;
+  }
+
   // Add the 'sticky-header' library if the sticky header setting is enabled.
   if (theme_get_setting('localgov_base_header_behaviour') !== 'default') {
 

--- a/localgov_base.theme
+++ b/localgov_base.theme
@@ -91,13 +91,25 @@ function localgov_base_form_system_theme_settings_alter(&$form, FormStateInterfa
   $form['localgov_base_mobile_breakpoint_js'] = [
     '#type'          => 'number',
     '#title'         => t('Mobile breakpoint for JavaScript'),
-    '#default_value' => theme_get_setting('localgov_base_mobile_breakpoint_js'),
+    '#default_value' => theme_get_setting('localgov_base_mobile_breakpoint_js') ? theme_get_setting('localgov_base_mobile_breakpoint_js') : 768,
     '#description'   => t('This is the mobile breakpoint in pixels. This is used by the JS to determine when to show the mobile menu. If left blank, this will default to 768px.'),
+    '#min'           => 0,
     '#attributes' => [
       'placeholder' => '768',
     ],
-
   ];
+
+  $form['#validate'][] = 'localgov_base_theme_settings_validate';
+}
+
+/**
+ * Validate the theme settings form.
+ */
+function localgov_base_theme_settings_validate(&$form, FormStateInterface $form_state): void {
+  // Check if the mobile breakpoint is a number.
+  if (!is_numeric($form_state->getValue('localgov_base_mobile_breakpoint_js'))) {
+    $form_state->setErrorByName('localgov_base_mobile_breakpoint_js', t('The mobile breakpoint must be a number.'));
+  }
 }
 
 /**

--- a/localgov_base.theme
+++ b/localgov_base.theme
@@ -109,6 +109,9 @@ function localgov_base_preprocess_html(&$variables): void {
     $mobile_breakpoint = theme_get_setting('localgov_base_mobile_breakpoint_js');
     $variables['#attached']['drupalSettings']['localgov_base']['mobileBreakpointJS'] = $mobile_breakpoint;
   }
+  else {
+    $variables['#attached']['drupalSettings']['localgov_base']['mobileBreakpointJS'] = 768;
+  }
 
   // Add the 'sticky-header' library if the sticky header setting is enabled.
   if (theme_get_setting('localgov_base_header_behaviour') !== 'default') {

--- a/localgov_base.theme
+++ b/localgov_base.theme
@@ -89,7 +89,7 @@ function localgov_base_form_system_theme_settings_alter(&$form, FormStateInterfa
   ];
 
   $form['localgov_base_mobile_breakpoint_js'] = [
-    '#type'          => 'textfield',
+    '#type'          => 'number',
     '#title'         => t('Mobile breakpoint for JavaScript'),
     '#default_value' => theme_get_setting('localgov_base_mobile_breakpoint_js'),
     '#description'   => t('This is the mobile breakpoint in pixels. This is used by the JS to determine when to show the mobile menu. If left blank, this will default to 768px.'),


### PR DESCRIPTION
Closes #669 

## What does this change?

Adds a theme setting for "JS mobile breakpoint" so different sites can have their JS mobile vs desktop at different widths. It defaults/fallsback to `768` which is our current value so no existing sites should be affected.

## How to test

Go to you custom theme settings if it's based on LocalGov Base, enter a numeric value in the JS mobile breakpoint field, check that the mobile menu works when your screen is below that value.

---
Thanks to [Big Blue Door](https://www.bigbluedoor.net/) for sponsoring my time to work on this.