### PR TITLE
Add custom attributes for prev-next component

### DIFF
--- a/components/prev-next/prev-next.twig
+++ b/components/prev-next/prev-next.twig
@@ -7,6 +7,8 @@
  */
 #}
 
+{% set prevNextAttributes = prevNextAttributes|default(create_attribute) %}
+
 {% set icon_path = icon_path|default('@localgov_base/includes/icons') %}
 {% set prev_icon = prev_icon|default('chevron-left') %}
 {% set next_icon = next_icon|default('chevron-right') %}
@@ -26,7 +28,7 @@
 {% endif %}
 #}
 
-<nav{{attributes.addClass(classes)}}>
+<nav{{prevNextAttributes.addClass(classes)}}>
   <ul class="lgd-prev-next__list">
     {% if prev_url %}
       <li class="lgd-prev-next__list-item lgd-prev-next__list-item--prev">


### PR DESCRIPTION
Closes #758 

## What does this change?

Adds a custom attribute for prev-next component, so other attributes (like node classes) don't pollute it.

## How to test

Embed the prev-next component in a node template. Check that the classes are:

```
<nav class="node node--type-page lgd-prev-next">...</nav>
```

Now, check out this branch and check the classes now DO NOT have the node classes in the `nav`:

```
<nav class="lgd-prev-next">...</nav>
```

