### PR TITLE
Override (remove) dialog libraries from backend themes to prevent CSS…

### DIFF
--- a/localgov_base.info.yml
+++ b/localgov_base.info.yml
@@ -37,3 +37,8 @@ libraries-extend:
     - localgov_base/localgov_eu_cookie_compliance
   localgov_subsites_paragraphs/localgov_accordion:
     - localgov_base/accordion
+
+libraries-override:
+  gin/dialog: false
+  gin/gin_dialog: false
+  claro/claro.drupal.dialog: false


### PR DESCRIPTION
… issues in frontend themes

<!-- See https://docs.localgovdrupal.org/contributing/ for guidelines on contributing. -->

## What does this change?

Removes libraries from inclusion in frontend themes, to prevent a styling problem with dialogs which occurs when frontend themes and admin themes are present on the same page. This is incurred by aggregation only. Aggregated CSS files are polluted when admin users use the site.


## How can we measure success?

CSS no longer broken and no other areas affected

## Have we considered potential risks?

Not 100% clear on the actual use case of the original inclusion of the libraries in question tbh!

## Images

See those on https://github.com/localgovdrupal/localgov_base/issues/748
