### PR TITLE
Update skip-to-content link to make it more pronounced

### DIFF
--- a/css/components/skip-link.css
+++ b/css/components/skip-link.css
@@ -4,6 +4,8 @@
 
 .skip-link:focus,
 .skip-link:hover {
+  display: block;
+  text-underline-offset: 3px;
   text-decoration: underline !important;
   text-decoration-thickness: max(3px, 0.1875rem, 0.12em) !important;
 }


### PR DESCRIPTION
Relates to #772 

## What does this change?

When you focus on the "Skip to content" link, it now spans 100% of it's container, and moves the underline slightly away from the text.

<img width="793" alt="Screenshot 2025-05-20 at 11 02 15" src="https://github.com/user-attachments/assets/873a3241-7fa8-4d56-8699-410feae912b7" />


## How to test

- Checkout this branch
- Tab to the 'skip to main content' link
- Check that it's now 100% of the container

## How can we measure success?

People can see the skip to content link easier when they focus on it
