### PR TITLE
Fix/1.x/776 guides prev next block template prints url fragement twice

### DIFF
--- a/js/guides.js
+++ b/js/guides.js
@@ -10,7 +10,7 @@
       // users, the focus stays at the top of the page.
       // This function checks if the URL contains a hash, and if so, focuses on
       // the element with the corresponding ID.
-      if (window.location.hash) {
+      if (window.location.hash && window.location.hash.length > 1) {
         const [element] = once('guidecontent', window.location.hash, context);
         if (element) {
           element.focus();

--- a/js/guides.js
+++ b/js/guides.js
@@ -4,17 +4,14 @@
 
 (function guidesScript(Drupal) {
   Drupal.behaviors.guides = {
-    attach() {
+    attach(context) {
       // When we click on a guide navigation link, we link to the top of the
       // Guide content. This is fine for visual users, but for screen reader
       // users, the focus stays at the top of the page.
       // This function checks if the URL contains a hash, and if so, focuses on
       // the element with the corresponding ID.
-      const path = window.location.hash;
-      // check if path links to id
-      if (path.includes('#')) {
-        const id = path.split('#')[1];
-        const element = document.querySelector(`#${id}`);
+      if (window.location.hash) {
+        const [element] = once('guidecontent', window.location.hash, context);
         if (element) {
           element.focus();
         }

--- a/js/guides.js
+++ b/js/guides.js
@@ -1,5 +1,7 @@
 /**
  * @file JS file for the Guides components.
+ *
+ * NOTE: this runs on every page load no matter if it's a Guide page or no.
  */
 
 (function guidesScript(Drupal) {

--- a/js/guides.js
+++ b/js/guides.js
@@ -1,7 +1,5 @@
 /**
  * @file JS file for the Guides components.
- *
- * NOTE: this runs on every page load no matter if it's a Guide page or no.
  */
 
 (function guidesScript(Drupal) {

--- a/templates/block/guides-prev-next-block.html.twig
+++ b/templates/block/guides-prev-next-block.html.twig
@@ -2,7 +2,7 @@
 {#
   Probably the parent module should take responsibility for this.
 
-  Note that the url fragment is added to the render array in localgov.theme.
+  Note that the url fragment's added to the render array in localgov_base.theme.
   Adding it there eliminates the need to render the array here.
 #}
 {% set next_url = next_url|default('') %}

--- a/templates/block/guides-prev-next-block.html.twig
+++ b/templates/block/guides-prev-next-block.html.twig
@@ -1,7 +1,12 @@
 {% set prev_next_type = 'guides' %}
-{# Probably the parent module should take responsibility for this. #}
-{% set next_url = next_url is not empty ? next_url|render ~ '#lgd-guides__title' : '' %}
-{% set prev_url = previous_url is not empty ? previous_url|render ~ '#lgd-guides__title' : '' %}
+{#
+  Probably the parent module should take responsibility for this.
+
+  Note that the url fragment is added to the render array in localgov.theme.
+  Adding it there eliminates the need to render the array here.
+#}
+{% set next_url = next_url|default('') %}
+{% set prev_url = previous_url|default('') %}
 {% set prev_title = previous_title %}
 
 {% include 'localgov_base:prev-next' %}


### PR DESCRIPTION
Closes #776 

<!-- See https://docs.localgovdrupal.org/contributing/ for guidelines on contributing. -->

## What does this change?

This makes the following changes:

- returns the theme's `guides-prev-next-block.html.twig` template to its pre Prev-Next SDC condition: namely it no longer sets a URL fragment on each of the Previous and Next links (NOTE: `localgov_base.theme` still does this),
- slightly rewrites the theme's `guides` behavior javascript for efficiency

## How to test

<!-- Provide instructions to help others verify the change. This could take the
form of "On main, do X and witness Y. On this branch, do X and witness Z. " -->

1. check out this branch in a running instance of LGD (the demo site, or any LGD site whose child theme has not modified Guides' Prev/Next links will do),
2. load a Guide Overview and/or Guide Page and verify that its Prev/Next links contain the fragment `#lgd-guides__title`, and _not_ `#lgd-guides__title#lgd-guides__title`
3. click a Prev/Next link and verify that the focused element on the loaded pages is, in fact, `#lgd-guides__title`

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be
simplified? What can be used to prove this? A filtered view of logs or
analytics, etc? -->

This should return the Prev/Next links to a slightly more accessible condition: the fragments in the URLs will refer to elements that _exist_ on the page and so can be focused, aiding keyboard navigation for users.

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error
require an alarm? Should user help, infosec, or legal be informed of this
change? Is private information guarded? Do we need to add anything in the
backlog? -->

n/a

## Images

<!-- Usually only applicable to UI changes, what did it look like before and
what will it look like after? -->

### Before

![image](https://github.com/user-attachments/assets/7c480783-612f-4feb-b58d-1677cac884eb)

### After

![image](https://github.com/user-attachments/assets/7102a63d-cff3-4cd3-82be-7ce442b5cf88)

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [x] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [x] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)

(The second two items don't apply to this change).