### PR TITLE
Update .lgd-row classes to use CSS grid

### DIFF
--- a/css/layout/grid.css
+++ b/css/layout/grid.css
@@ -41,8 +41,8 @@
 .lgd-row__two-thirds,
 .lgd-row__three-quarters,
 .lgd-row__full {
-  width: 100%;
   grid-column: span 12;
+  width: 100%;
 }
 
 @media screen and (min-width: 48rem) {

--- a/css/layout/grid.css
+++ b/css/layout/grid.css
@@ -17,9 +17,11 @@
   - .lgd-row--thirds - direct descendants are all 33% each
   - .lgd-row--quarters - direct descendants are all 25% each
 */
+
 .lgd-row {
-  display: flex;
-  flex-wrap: wrap;
+  display: grid;
+  gap: var(--grid-column-spacing);
+  grid-template-columns: repeat(12, 1fr);
 }
 
 .lgd-row--centered {
@@ -28,10 +30,6 @@
 
 .lgd-row--vertically-centered {
   align-items: center;
-}
-
-.lgd-row > * {
-  margin-inline: calc(var(--grid-column-spacing) / 2);
 }
 
 .lgd-row__one-quarter,
@@ -43,7 +41,8 @@
 .lgd-row__two-thirds,
 .lgd-row__three-quarters,
 .lgd-row__full {
-  width: calc(100% - var(--grid-column-spacing));
+  width: 100%;
+  grid-column: span 12;
 }
 
 @media screen and (min-width: 48rem) {
@@ -55,27 +54,26 @@
   .lgd-row--halves > *,
   .lgd-row__two-thirds,
   .lgd-row__three-quarters {
-    width: calc(50% - var(--grid-column-spacing));
+    grid-column: span 6;
   }
 }
 
 @media screen and (min-width: 60rem) {
   .lgd-row__one-quarter,
   .lgd-row--quarters > * {
-    width: calc(25% - var(--grid-column-spacing));
+    grid-column: span 3;
   }
 
   .lgd-row__one-third,
   .lgd-row--thirds > * {
-    width: calc((100% / 3) - var(--grid-column-spacing));
+    grid-column: span 4;
   }
 
   .lgd-row__two-thirds {
-    width: calc((100% / 3 * 2) - var(--grid-column-spacing));
+    grid-column: span 8;
   }
-
   .lgd-row__three-quarters {
-    width: calc(75% - var(--grid-column-spacing));
+    grid-column: span 9;
   }
 }
 


### PR DESCRIPTION
Closes #666 

## What does this change?

Rewrites our `.lgd-row` grid system to use CSS Grid instead of flexbox. This means we will no longer have the annoying issue with the small margins on the left/right of grids that mean things don't line up as nicely as we'd like them to without extra CSS overrides.

## How to test

Click around the website and make sure the grid is working, but more importantly marvel at how all the items line up correctly.

## How can we measure success?

Waaaaay few overrides for our layout in custom themes.

## Images

<img width="1250" alt="Screenshot 2025-05-23 at 14 09 48" src="https://github.com/user-attachments/assets/53c0cbca-1160-48f2-8f95-ed4157b63b47" />

