### PR TITLE
Add styles for alt text

### DIFF
--- a/css/base/base.css
+++ b/css/base/base.css
@@ -148,6 +148,18 @@ img {
   height: auto;
 }
 
+img[alt] {
+  font-style: var(--image-alt-font-style);
+  font-size: var(--image-alt-font-size-large);
+  text-wrap: balance;
+  color: var(--image-alt-color);
+}
+img[data-img-loading-error] {
+  padding: var(--image-alt-spacing);
+  border: var(--image-alt-border);
+  background-color: var(--image-alt-bg-color);
+}
+
 p,
 ul,
 ol,

--- a/css/base/variables.css
+++ b/css/base/variables.css
@@ -589,4 +589,12 @@ body {
   /* Accordion */
   --accordion-icon-closed: "+";
   --accordion-icon-opened: "-";
+
+  /* Image */
+  --image-alt-font-style: italic;
+  --image-alt-font-size-large: var(--font-size-large);
+  --image-alt-color: var(--color-black);
+  --image-alt-spacing: var(--spacing);
+  --image-alt-border: var(--border);
+  --image-alt-bg-color: var(--color-grey-lightest);
 }

--- a/js/images.js
+++ b/js/images.js
@@ -1,0 +1,18 @@
+/**
+ * @file JS file for images.
+ */
+
+(function lgdImagesScript(Drupal) {
+  Drupal.behaviors.lgdImages = {
+    attach(context) {
+      const images = once('allImages', 'img', context);
+      if (images.length) {
+        images.forEach((image) => {
+          image.onerror = () => {
+            image.setAttribute('data-img-loading-error', '');
+          };
+        });
+      }
+    },
+  };
+})(Drupal);

--- a/localgov_base.libraries.yml
+++ b/localgov_base.libraries.yml
@@ -20,6 +20,7 @@ global:
     - localgov_base/grid
     - localgov_base/header
     - localgov_base/footer
+    - localgov_base/images
     - localgov_base/callout
     - localgov_base/secondary-menu
     - localgov_base/wysiwyg-styles
@@ -363,3 +364,10 @@ accordion:
   css:
     theme:
       css/components/accordion.css: {}
+
+images:
+  js:
+    js/images.js: {}
+  dependencies:
+    - core/drupal
+    - core/once


### PR DESCRIPTION
Closes #781 

## What does this change?

1. Adds some CSS for alt text
2. If JS is enabled, adds a data attribute to the img tag if there's an error. Uses that data attribute to add additional styles to alt text.

## How to test

Load any page with an image on it. Inspect the image and set the `src` attribute to empty.

## How can we measure success?

People appreciate that we put some effort into styling alt tags.

## Images

Images load correctly

<img width="1180" alt="Screenshot 2025-05-26 at 15 25 27" src="https://github.com/user-attachments/assets/abcb6549-b5f6-4789-aaa2-7fed5d44c608" />

Images do not load correctly

<img width="1191" alt="Screenshot 2025-05-26 at 15 24 59" src="https://github.com/user-attachments/assets/3c729046-1f3b-4280-a0e5-d10e5f61a682" />

Images do not load but javascript is running

<img width="1179" alt="Screenshot 2025-05-26 at 15 25 12" src="https://github.com/user-attachments/assets/17def352-3bf0-4779-97cc-114769cac356" />

---
Thanks to [Big Blue Door](https://www.bigbluedoor.net/) for sponsoring my time to work on this.