### PR TITLE
Update grid for items to fill space on small screen

### DIFF
--- a/css/layout/grid.css
+++ b/css/layout/grid.css
@@ -42,6 +42,7 @@
 .lgd-row__three-quarters,
 .lgd-row__full {
   width: 100%;
+  grid-column: span 1;
 }
 
 @media screen and (min-width: 48rem) {

--- a/css/layout/grid.css
+++ b/css/layout/grid.css
@@ -21,7 +21,7 @@
 .lgd-row {
   display: grid;
   gap: var(--grid-column-spacing);
-  grid-template-columns: repeat(12, 1fr);
+  grid-template-columns: 1fr;
 }
 
 .lgd-row--centered {
@@ -41,11 +41,18 @@
 .lgd-row__two-thirds,
 .lgd-row__three-quarters,
 .lgd-row__full {
-  grid-column: span 12;
   width: 100%;
 }
 
 @media screen and (min-width: 48rem) {
+  .lgd-row {
+    grid-template-columns: repeat(12, 1fr);
+  }
+
+  .lgd-row__full {
+    grid-column: span 12;
+  }
+
   .lgd-row__one-quarter,
   .lgd-row--quarters > *,
   .lgd-row__one-third,


### PR DESCRIPTION
Closes #788 

## What does this change?

A slightly better way to make sure things take up 100% of their container on small screens without horizontal scrolling being added if there's a large `gap` set.

## How to test

Without this patch, set `--grid-column-spacing` to `3rem`, visit a page on a small screen and check if there's any horizontal scroll.

Checkout this branch, and the horizontal scrolling should be gone.

