### PR TITLE
Wrap icon and text in <a> tag

### DIFF
--- a/css/components/link.css
+++ b/css/components/link.css
@@ -13,6 +13,7 @@
 }
 
 .link--button-style .link-wrapper {
+  position: relative;
   padding: var(--button-padding-vertical) var(--button-padding-horizontal) var(--button-padding-vertical) var(--button-padding-horizontal);
   color: var(--button-text-color);
   border: var(--border);
@@ -36,7 +37,11 @@
   text-decoration: none;
   color: inherit;
 }
-
+.link--button-style a::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+}
 .link--button-style:focus .link-wrapper,
 .link--button-style:hover .link-wrapper {
   text-decoration: underline;

--- a/css/components/link.css
+++ b/css/components/link.css
@@ -3,6 +3,10 @@
   align-items: center;
 }
 
+.link-content > a {
+  display: flex;
+}
+
 .link-icon {
   flex-shrink: 0;
   margin-inline-end: var(--link-icon-margin);

--- a/css/components/link.css
+++ b/css/components/link.css
@@ -9,9 +9,9 @@
 }
 
 .link-content > a::after {
-  content: "";
   position: absolute;
   inset: 0;
+  content: "";
 }
 
 .link-icon {

--- a/css/components/link.css
+++ b/css/components/link.css
@@ -1,4 +1,5 @@
 .link-wrapper {
+  position: relative;
   display: flex;
   align-items: center;
 }
@@ -7,13 +8,18 @@
   display: flex;
 }
 
+.link-content > a::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+}
+
 .link-icon {
   flex-shrink: 0;
   margin-inline-end: var(--link-icon-margin);
 }
 
 .link--button-style .link-wrapper {
-  position: relative;
   padding: var(--button-padding-vertical) var(--button-padding-horizontal) var(--button-padding-vertical) var(--button-padding-horizontal);
   color: var(--button-text-color);
   border: var(--border);
@@ -37,11 +43,7 @@
   text-decoration: none;
   color: inherit;
 }
-.link--button-style a::after {
-  content: "";
-  position: absolute;
-  inset: 0;
-}
+
 .link--button-style:focus .link-wrapper,
 .link--button-style:hover .link-wrapper {
   text-decoration: underline;

--- a/templates/paragraphs/paragraph--localgov-link.html.twig
+++ b/templates/paragraphs/paragraph--localgov-link.html.twig
@@ -60,13 +60,13 @@
 
   {% if paragraph.localgov_url.value %}
     <div class="link-wrapper">
-      {% include "@localgov_base/includes/icons/icon.html.twig" with {
-          icon_name: title_icon,
-          icon_classes: 'link-icon',
-        }
-      %}
       <div class="link-content">
         <a href="{{ content.localgov_url.0 }}">
+          {% include "@localgov_base/includes/icons/icon.html.twig" with {
+              icon_name: title_icon,
+              icon_classes: 'link-icon',
+            }
+          %}
           {{ content.localgov_title.0 }}
         </a>
       </div>


### PR DESCRIPTION
Closes #787 

## What does this change?

Moves the icon in the link paragraph into the `a` tag so both the text and the icon are clickable.
