### PR TITLE
fix: missing prev-next attributes for nav

### DIFF
--- a/components/prev-next/prev-next.twig
+++ b/components/prev-next/prev-next.twig
@@ -7,7 +7,7 @@
  */
 #}
 
-{% set prevNextAttributes = prevNextAttributes|default(create_attribute) %}
+{% set prevNextAttributes = create_attribute(prevNextAttributes|default({})) %}
 
 {% set icon_path = icon_path|default('@localgov_base/includes/icons') %}
 {% set prev_icon = prev_icon|default('chevron-left') %}


### PR DESCRIPTION
<!-- See https://docs.localgovdrupal.org/contributing/ for guidelines on contributing. -->

## What does this change?

Recent changes in prev-next have broken tests, see https://github.com/localgovdrupal/localgov/actions/runs/15327716159/job/43126523978

This is because the classes are missing on the `<nav>` element

With this PR it reinstates these to look like (publications as an example);
```
<nav class="lgd-prev-next lgd-prev-next--publications">
```

Currently these classes are missing and this is shown
```
<nav>
```