### PR TITLE
Feature/2.x/805 add default accessible label to templates using localgov prev next

### DIFF
--- a/components/prev-next/prev-next.component.yml
+++ b/components/prev-next/prev-next.component.yml
@@ -74,3 +74,20 @@ props:
       description: >
         The actual URL for the Next link. If empty, the entire link will
         not be rendered.
+    prev_next_nav_aria_label:
+      type: string
+      title: Prev-Next nav label
+      description: Translated label for parent <nav> element. Optional since
+        an aria-label may also be set in prevNextAttributes or an accessible
+        value provided as part of the prev_next_pre_content slot.
+slots:
+  prev_next_pre_content:
+    title: Prev-Next pre-content
+    description:
+      Use this slot to add arbitrary content prior to the nav list in the
+      component. This is useful for adding an accessible text label when
+      aria-label isn't used.
+  prev_next_post_content:
+    title: Prev-Next post-content
+    description:
+      Use this slot to add arbitrary content after nav list in the component.

--- a/components/prev-next/prev-next.component.yml
+++ b/components/prev-next/prev-next.component.yml
@@ -10,6 +10,11 @@ status: stable
 props:
   type: object
   properties:
+    prevNextAttributes:
+      type: object
+      title: Prev-Next attributes
+      description: a Drupal attributes object. Will not override default
+        classes.
     prev_next_type:
       type: string
       title: Prev-Next type

--- a/components/prev-next/prev-next.twig
+++ b/components/prev-next/prev-next.twig
@@ -8,6 +8,9 @@
 #}
 
 {% set prevNextAttributes = create_attribute(prevNextAttributes|default({})) %}
+{% if prev_next_nav_aria_label is not empty %}
+  {% do prevNextAttributes.setAttribute('aria-label', prev_next_nav_aria_label) %}
+{% endif %}
 
 {% set icon_path = icon_path|default('@localgov_base/includes/icons') %}
 {% set prev_icon = prev_icon|default('chevron-left') %}
@@ -29,6 +32,9 @@
 #}
 
 <nav{{prevNextAttributes.addClass(classes)}}>
+  {% block prev_next_pre_content %}
+    {{ prev_next_pre_content }}
+  {% endblock %}
   <ul class="lgd-prev-next__list">
     {% if prev_url %}
       <li class="lgd-prev-next__list-item lgd-prev-next__list-item--prev">
@@ -69,4 +75,7 @@
       </li>
     {% endif %}
   </ul>
+  {% block postv_next_post_content %}
+    {{ prev_next_post_content }}
+  {% endblock %}
 </nav>

--- a/templates/block/guides-prev-next-block.html.twig
+++ b/templates/block/guides-prev-next-block.html.twig
@@ -1,4 +1,4 @@
-{% set nav_id = 'guides-prev-next' %}
+{% set nav_id = 'guides-prev-next-' ~ random() %}
 {% set prevNextAttributes = create_attribute({ id: nav_id }) %}
 {% set prev_next_type = 'guides' %}
 {#

--- a/templates/block/guides-prev-next-block.html.twig
+++ b/templates/block/guides-prev-next-block.html.twig
@@ -1,3 +1,5 @@
+{% set nav_id = 'guides-prev-next' %}
+{% set prevNextAttributes = create_attribute({ id: nav_id }) %}
 {% set prev_next_type = 'guides' %}
 {#
   Probably the parent module should take responsibility for this.
@@ -9,4 +11,8 @@
 {% set prev_url = previous_url|default('') %}
 {% set prev_title = previous_title %}
 
-{% include 'localgov_base:prev-next' %}
+{% embed 'localgov_base:prev-next' %}
+  {% block prev_next_pre_content %}
+    <h2 class="visually-hidden" aria-labelledby="{{ nav_id }}">{{ 'Guides navigation'|t }}</h2>
+  {% endblock %}
+{% endembed %}

--- a/templates/block/localgov-blogs-prev-next-block.html.twig
+++ b/templates/block/localgov-blogs-prev-next-block.html.twig
@@ -1,2 +1,8 @@
+{% set nav_id = 'blogs-prev-next' %}
+{% set prevNextAttributes = create_attribute({ id: nav_id }) %}
 {% set prev_next_type = 'blog' %}
-{% include 'localgov_base:prev-next' %}
+{% embed 'localgov_base:prev-next' %}
+  {% block prev_next_pre_content %}
+    <h2 class="visually-hidden" aria-labelledby="{{ nav_id }}">{{ 'Blog navigation'|t }}</h2>
+  {% endblock %}
+{% endembed %}

--- a/templates/block/localgov-blogs-prev-next-block.html.twig
+++ b/templates/block/localgov-blogs-prev-next-block.html.twig
@@ -1,4 +1,4 @@
-{% set nav_id = 'blogs-prev-next' %}
+{% set nav_id = 'blogs-prev-next-' ~ random() %}
 {% set prevNextAttributes = create_attribute({ id: nav_id }) %}
 {% set prev_next_type = 'blog' %}
 {% embed 'localgov_base:prev-next' %}

--- a/templates/navigation/book-navigation--publication.html.twig
+++ b/templates/navigation/book-navigation--publication.html.twig
@@ -32,9 +32,15 @@
 #}
 
 {% if has_links %}
+  {% set nav_id = 'publication-prev-next' %}
+  {% set prevNextAttributes = create_attribute({ id: nav_id }) %}
   {# This uses previous_* vars, prev-next uses prev_*, so we translate. #}
   {% set show_title = true %}
   {% set prev_next_type = 'publications' %}
 
-  {% include 'localgov_base:prev-next' %}
+  {% embed 'localgov_base:prev-next' %}
+    {% block prev_next_pre_content %}
+      <h2 class="visually-hidden" aria-labelledby="{{ nav_id }}">{{ 'Publication navigation'|t }}</h2>
+    {% endblock %}
+  {% endembed %}
 {% endif %}

--- a/templates/navigation/book-navigation--publication.html.twig
+++ b/templates/navigation/book-navigation--publication.html.twig
@@ -32,7 +32,7 @@
 #}
 
 {% if has_links %}
-  {% set nav_id = 'publication-prev-next' %}
+  {% set nav_id = 'publication-prev-next-' ~ random() %}
   {% set prevNextAttributes = create_attribute({ id: nav_id }) %}
   {# This uses previous_* vars, prev-next uses prev_*, so we translate. #}
   {% set show_title = true %}

--- a/templates/views/views-view-list--localgov-step-by-step-navigation--prev-next.html.twig
+++ b/templates/views/views-view-list--localgov-step-by-step-navigation--prev-next.html.twig
@@ -36,7 +36,7 @@
  */
 #}
 
-{% set nav_id = 'step-by-step-prev-next' %}
+{% set nav_id = 'step-by-step-prev-next-' ~ random() %}
 {% set prevNextAttributes = create_attribute({ id: nav_id }) %}
 {% set prev_next_type = 'step_by_step' %}
 {% set prev_url = has_prev_step ? path('entity.node.canonical', {'node': prev_step_nid }) : '' %}

--- a/templates/views/views-view-list--localgov-step-by-step-navigation--prev-next.html.twig
+++ b/templates/views/views-view-list--localgov-step-by-step-navigation--prev-next.html.twig
@@ -36,8 +36,14 @@
  */
 #}
 
+{% set nav_id = 'step-by-step-prev-next' %}
+{% set prevNextAttributes = create_attribute({ id: nav_id }) %}
 {% set prev_next_type = 'step_by_step' %}
 {% set prev_url = has_prev_step ? path('entity.node.canonical', {'node': prev_step_nid }) : '' %}
 {% set next_url = has_next_step ? path('entity.node.canonical', {'node': next_step_nid }) : ''  %}
 
-{% include 'localgov_base:prev-next' %}
+{% embed 'localgov_base:prev-next' %}
+  {% block prev_next_pre_content %}
+    <h2 class="visually-hidden" aria-labelledby="{{ nav_id }}">{{ 'Step by step navigation'|t }}</h2>
+  {% endblock %}
+{% endembed %}


### PR DESCRIPTION
Re: #805

<!-- See https://docs.localgovdrupal.org/contributing/ for guidelines on contributing. -->

## What does this change?

This makes several changes:

- documents existing but undocumented prop `prevNextAttributes` in `prev-next.component.yml`
- adds new `prev_next_nav_aria_label` prop for convenience (i.e. since this can also be set using `prevNextAttributes`)
- adds new `prev_next_pre_content` slot to add content before the Prev and Next links
- adds new `prev_next_post_content` slot to add content after the Prev and Next links
- uses `prev_next_pre_content` slot to add a labelled, visually-hidden heading to Blog template
- uses `prev_next_pre_content` slot to add a labelled, visually-hidden heading to Guides template
- uses `prev_next_pre_content` slot to add a labelled, visually-hidden heading to Publication template
- uses `prev_next_pre_content` slot to add a labelled, visually-hidden heading to Step by Step template

The new labels all use Drupal's stock pattern: an `aria-labelledby` attribute on the `<nav>` element referring to a visually-hidden child `<h2>` with a matching `id` attribute.

## How to test

<!-- Provide instructions to help others verify the change. This could take the
form of "On main, do X and witness Y. On this branch, do X and witness Z. " -->

Test all of the following with demo content (not sure what module the Blog template requires):

- /publications/publications-cover-page-demo-content/petitions-scheme-publications-demo-content-1
  - browser: Prev-Next heading not visible
  - screenreader: h2 'Publication navigation' announced
- /order-copy-certificate/order-copy-certificate
  - browser: Prev-Next heading not visible
  - screenreader: h2 'Guides navigation' announced
- /adult-health-and-social-care/step-by-step/request-support-adult-step-step/choosing-how-manage-your
  - browser: Prev-Next heading not visible
  - screenreader: h2 'Step by step navigation' announced

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be
simplified? What can be used to prove this? A filtered view of logs or
analytics, etc? -->

- the various `<nav>` elements wrapping the Prev-Next links will now have an accessible text label by default

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error
require an alarm? Should user help, infosec, or legal be informed of this
change? Is private information guarded? Do we need to add anything in the
backlog? -->

For existing overrides of the template, a new `aria-labelledby` and `h2` will appear:

- if the theme template uses the SDC and has _not_ provided its own accessible label, the component will now have one; this is an improvement
- if the theme template uses the SDC _has_ provided its own label using the only currently available method (`aria-label`), [the `<nav>`'s `aria-labelledby` attribute plus its new label will override the theme's label](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-labelledby#benefits_and_drawbacks); this is _probably_ not serious but could be a problem where e.g. the new label string is not translated on a multilingual site

## Images

n/a

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [x] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [x] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] ~[Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)~ 
-   [ ] ~[The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)~