### PR TITLE
fix: switches secondary nav max-height from 'auto' to 'none' at deskt…

### DIFF
--- a/css/components/secondary-menu.css
+++ b/css/components/secondary-menu.css
@@ -29,7 +29,7 @@
 
   .region-secondary-menu .menu {
     overflow-y: initial;
-    max-height: auto;
+    max-height: none;
     column-count: var(--secondary-menu-column-count);
   }
 }


### PR DESCRIPTION
Re: #807 

...op sizes

"auto" is not a possible value, so it fails to unset the max-height value set for mobile/tablet sizes, sometimes obscuring menu items.

## To reproduce

This is relatively difficult to trigger on the LGD demo because the menu only has three items. The following steps make it seem absurd, but with menus containing 20+ items, it's easier to trigger :)

1. load a page like e.g. https://demo.localgovdrupal.org/localgov-drupal-demo
2. in the browser's css rules panel, find the selector `.region-secondary-menu .menu-item > a`
3. to that selector, add `font-size: 5em;`

The result is like this:

![image](https://github.com/user-attachments/assets/b448e46f-d013-453c-99f1-0552ea8ef249)

<!-- See https://docs.localgovdrupal.org/contributing/ for guidelines on contributing. -->

## What does this change?

<!-- A pull request should have enough detail to be understandable far in the
future. e.g what is the problem/why is the change needed, how does it solve it
and any questions or points of discussion. Prefer copying information from a
Trello card (for example) over linking to it; the card may not always exist and
reviewers may not have access to the board. -->

The new code uses a valid keyword for `max-height` in `secondary-nav.css`.

## How to test

<!-- Provide instructions to help others verify the change. This could take the
form of "On main, do X and witness Y. On this branch, do X and witness Z. " -->

Test as per "To reproduce" above

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be
simplified? What can be used to prove this? A filtered view of logs or
analytics, etc? -->

If the new desktop `max-height` value is honoured by browsers.

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error
require an alarm? Should user help, infosec, or legal be informed of this
change? Is private information guarded? Do we need to add anything in the
backlog? -->

This comes with very few risks:

- in most cases, it will be undetectable
- in some cases (like the one that prompted this issue), it will _fix_ a problem
- in a very few cases, where a child theme's css is unintentionally (i.e. due to this bug) relying on the _mobile_ styles' `max-height` value _at desktop sizes_, along with something like `oveflow-y: scroll;`, this could cause menu items to exceed the bounds of the menu container; this would be correctable with a single css rule

## Images

<!-- Usually only applicable to UI changes, what did it look like before and
what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)