### PR TITLE
Set show_title to false instead of NULL in blogs prev-next block

### DIFF
--- a/templates/block/localgov-blogs-prev-next-block.html.twig
+++ b/templates/block/localgov-blogs-prev-next-block.html.twig
@@ -1,6 +1,7 @@
 {% set nav_id = 'blogs-prev-next-' ~ random() %}
 {% set prevNextAttributes = create_attribute({ id: nav_id }) %}
 {% set prev_next_type = 'blog' %}
+{% set show_title = false %}
 {% embed 'localgov_base:prev-next' %}
   {% block prev_next_pre_content %}
     <h2 class="visually-hidden" aria-labelledby="{{ nav_id }}">{{ 'Blog navigation'|t }}</h2>


### PR DESCRIPTION
Implements https://github.com/localgovdrupal/localgov_base/pull/836 for 2x 

This issue was discovered during test failures of microsites.

show_title gets set to NULL by the blog module. The single directory expects a boolean so we set to false here in the template instead. 