### PR TITLE
Adds aria label for directory facets blocks

### DIFF
--- a/localgov_base.theme
+++ b/localgov_base.theme
@@ -385,6 +385,17 @@ function localgov_base_preprocess_block(&$variables): void {
     }
   }
 
+  // Add a decent aria label to the facets blocks.
+  if (in_array($variables['base_plugin_id'], ['localgov_directories_channel_search_block', 'facet_block'])) {
+    if ($variables['elements']['#configuration']['label_display'] === '0') {
+      $routeMatch = \Drupal::routeMatch();
+      $node = $routeMatch->getParameter('node');
+      $node_title = $node instanceof NodeInterface ? $node->getTitle() : '';
+      $variables['attributes']['aria-label'] = t('Search') . ' ' . $node_title;
+      $variables['attributes']['role'] = 'search';
+    }
+  }
+
   // Add vertical or horizontal class to the guides navigation block.
   // In config, this will default to vertical for new installations, but remain
   // horizontal for existing installations.

--- a/localgov_base.theme
+++ b/localgov_base.theme
@@ -386,7 +386,7 @@ function localgov_base_preprocess_block(&$variables): void {
   }
 
   // Add a decent aria label to the facets blocks.
-  if (in_array($variables['base_plugin_id'], ['localgov_directories_channel_search_block', 'facet_block'])) {
+  if (in_array($variables['base_plugin_id'], ['localgov_directories_channel_search_block', 'facet_block'], TRUE)) {
     if ($variables['elements']['#configuration']['label_display'] === '0') {
       $routeMatch = \Drupal::routeMatch();
       $node = $routeMatch->getParameter('node');


### PR DESCRIPTION
Closes #842

## What does this change?

Checks if the directory channel search block and/or directory channel facets block have their label hidden. If so, add the label as an aria-label so screen reader users will understand what these blocks are, since they come before the H1 in the page.

---
Thanks to [Big Blue Door](https://www.bigbluedoor.net/) for sponsoring my time to work on this.