### PR TITLE
Uses document/media name instead of file name if available

### DIFF
--- a/localgov_base.theme
+++ b/localgov_base.theme
@@ -420,9 +420,22 @@ function localgov_base_preprocess_file_link(&$variables): void {
   // 123.45 KB -> 123.45KB
   $variables['file_size'] = strtr($variables['file_size'], [' ' => '']);
 
+  // Load media entity from file.
+  $media_id = $file->_referringItem->getParent()->getParent()->getEntity()->get('mid')->getString();
+  $media = \Drupal\media\Entity\Media::load($media_id);
+  $media_name = $media->get('name')->getString();
+
   if (isset($variables['link']['#title'])) {
+    $document_title = $variables['link']['#title'];
+
+    if ($media_name && $media_name !== $document_title) {
+      // If the media name is set and different to the $variables['link']['#title'],
+      // we will use that instead.
+      $document_title = $media_name;
+    }
+
     $variables['link']['#title'] = [
-      '#markup' => "{$variables['link']['#title']} <span class=\"file-meta\">(<span class=\"file-type\">{$variables['file_type']}</span>, <span class=\"file-size\">{$variables['file_size']}</span>)</span>",
+      '#markup' => "{$document_title} <span class=\"file-meta\">(<span class=\"file-type\">{$variables['file_type']}</span>, <span class=\"file-size\">{$variables['file_size']}</span>)</span>",
     ];
   }
   else {


### PR DESCRIPTION
Closes #848 

## What does this change?

If the name field has been filled in for a document media item, it will use this instead of the file name when displaying files, e.g. "My File (pdf, 2MB)" instead of "my-file.pdf (pdf, 2MB)"

---
Thanks to [Big Blue Door](https://www.bigbluedoor.net/) for sponsoring my time to work on this.