### PR TITLE
Adds title to prev/next for step-by-step

### DIFF
--- a/templates/views/views-view-list--localgov-step-by-step-navigation--prev-next.html.twig
+++ b/templates/views/views-view-list--localgov-step-by-step-navigation--prev-next.html.twig
@@ -42,6 +42,10 @@
 {% set prev_url = has_prev_step ? path('entity.node.canonical', {'node': prev_step_nid }) : '' %}
 {% set next_url = has_next_step ? path('entity.node.canonical', {'node': next_step_nid }) : ''  %}
 
+{% set show_title = TRUE %}
+{% set prev_title = has_prev_step ? prev_step_title %}
+{% set next_title = has_next_step ? next_step_title %}
+
 {% embed 'localgov_base:prev-next' %}
   {% block prev_next_pre_content %}
     <h2 class="visually-hidden" aria-labelledby="{{ nav_id }}">{{ 'Step by step navigation'|t }}</h2>


### PR DESCRIPTION
Closes #795 

## What does this change?

Adds title to prev/next for step-by-step

## How to test

Currently step titles are not on the prev/next steps. With this PR, you should see them.

## Have we considered potential risks?

Some sites might not want step titles.

---
Thanks to [Big Blue Door](https://www.bigbluedoor.net/) for sponsoring my time to work on this.