### PR TITLE
check media item exists before loading it

### DIFF
--- a/localgov_base.theme
+++ b/localgov_base.theme
@@ -8,7 +8,6 @@
 use Drupal\Component\Utility\Crypt;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Url;
-use Drupal\media\Entity\Media;
 use Drupal\media\MediaInterface;
 use Drupal\node\NodeInterface;
 use Drupal\views\ViewExecutable;

--- a/localgov_base.theme
+++ b/localgov_base.theme
@@ -423,13 +423,13 @@ function localgov_base_preprocess_file_link(&$variables): void {
   $variables['file_size'] = strtr($variables['file_size'], [' ' => '']);
 
   // Load media entity from file.
-  $media_id = $file->_referringItem?->getParent()?->getParent()?->getEntity()?->get('mid')?->getString();
-  $media = $media_id ? Media::load($media_id) : NULL;
+  $entity = $file->_referringItem?->getParent()?->getParent()?->getEntity();
+  $media = ($entity instanceof MediaInterface) ? $entity : NULL;
 
   if (isset($variables['link']['#title'])) {
     $document_title = $variables['link']['#title'];
 
-    if ($media instanceof MediaInterface) {
+    if ($media) {
       $media_name = $media->get('name')->getString();
       // If the media name is set and different to the
       // $variables['link']['#title'], we will use that instead.


### PR DESCRIPTION
Closes #862 

## What does this change?

I removed the attempt to get the media ID using the non-existent mid field:

```php
$media_id = $file->_referringItem?->getParent()?->getParent()?->getEntity()?->get('mid')?->getString();
$media = $media_id ? Media::load($media_id) : NULL;
```

Instead, I directly check if the entity is a Media entity:

```php
$entity = $file->_referringItem?->getParent()?->getParent()?->getEntity();
$media = ($entity instanceof \Drupal\media\MediaInterface) ? $entity : NULL;
```

This change eliminates the need to get the media ID and then load the media entity again. It directly uses the entity if it's already a Media entity, which is more efficient and avoids the error with the non-existent mid field.

---
Thanks to [Big Blue Door](https://www.bigbluedoor.net/) for sponsoring my time to work on this.