### PR TITLE
places site-slogan inside .branding class

### DIFF
--- a/templates/block/block--system-branding-block.html.twig
+++ b/templates/block/block--system-branding-block.html.twig
@@ -15,18 +15,23 @@
 #}
 
 {% block content %}
-  {% if site_logo %}
-    <div class="branding">
-      <div class="branding__item branding__item--logo">
-        <a href="{{ path('<front>') }}" rel="home" class="branding__logo">
-          <img src="{{ site_logo }}" alt="{{ site_name ? site_name : 'Home'|t }}" />
-        </a>
-      </div>
-    </div>
-  {% endif %}
-  {% if site_slogan %}
-    <div class="branding__item branding__item--slogan">
-      {{ site_slogan }}
-    </div>
-  {% endif %}
+	{% if site_logo or site_slogan %}
+		<div class="branding">
+
+      {% if site_logo %}
+				<div class="branding__item branding__item--logo">
+					<a href="{{ path('<front>') }}" rel="home" class="branding__logo">
+						<img src="{{ site_logo }}" alt="{{ site_name ? site_name : 'Home'|t }}"/>
+					</a>
+				</div>
+			{% endif %}
+
+			{% if site_slogan %}
+				<div class="branding__item branding__item--slogan">
+					{{ site_slogan }}
+				</div>
+			{% endif %}
+
+		</div>
+	{% endif %}
 {% endblock %}


### PR DESCRIPTION
Closes #869

## What does this change?

places site-slogan inside .branding class to it properly follows our BEM naming conventions.

---
Thanks to [Big Blue Door](https://www.bigbluedoor.net/) for sponsoring my time to work on this.