### PR TITLE
only print link if it has a value

### DIFF
--- a/css/components/callout-box.css
+++ b/css/components/callout-box.css
@@ -18,7 +18,14 @@
   background: var(--call-out-box-bg-color);
 }
 
+.call-out-box__content .field--name-localgov-body-text > :last-child {
+  /* Ensure we don't have extra space if there is no call out link */
+  margin-block-end: 0;
+}
+
 .call-out-box__link {
+  display: inline-block;
+  margin-block-start: var(--vertical-rhythm-spacing);
   padding: var(--call-out-box-link-padding);
   color: var(--call-out-box-bg-color);
   background-color: var(--call-out-box-text-color);

--- a/templates/paragraphs/paragraph--localgov-call-out-box.html.twig
+++ b/templates/paragraphs/paragraph--localgov-call-out-box.html.twig
@@ -66,12 +66,16 @@
     {% endif %}
 
     {{ content|without('localgov_button', 'localgov_background_image', 'localgov_colour_theme', 'localgov_header_text', 'localgov_heading_level', 'localgov_opens_in_a_new_window') }}
-    <a href="{{ button_url }}" class="call-out-box__link"
-      {% if open_in_new_window %} target="_blank" {% endif %}>
-      <span>{{ paragraph.localgov_button.getValue[0].title }}</span>
-      {% if open_in_new_window %}
-        <span class="visually-hidden"> {{ '(opens in a new window)'|t }}</span>
-      {% endif %}
-    </a>
+
+    {% if button_url %}
+      <a href="{{ button_url }}" class="call-out-box__link"
+        {% if open_in_new_window %} target="_blank" {% endif %}>
+        <span>{{ paragraph.localgov_button.getValue[0].title }}</span>
+        {% if open_in_new_window %}
+          <span class="visually-hidden"> {{ '(opens in a new window)'|t }}</span>
+        {% endif %}
+      </a>
+    {% endif %}
+
   </div>
 </div>


### PR DESCRIPTION
Closes #866 

## What does this change?

1. Adds an `if` clause to only print the link field if it has a value
2. Remove the space from below the body of the call out 
3. Add the space to the link field instead, so it's only available if there is an actual link

Call out - no link:

<img width="1182" height="174" alt="Screenshot 2025-10-20 at 11 03 44" src="https://github.com/user-attachments/assets/44fe2f00-bdee-46ca-a2a1-fbc821e442eb" />

Call out - with link:

<img width="1175" height="227" alt="Screenshot 2025-10-20 at 11 03 49" src="https://github.com/user-attachments/assets/a2230830-feba-4741-9aae-7e143d416c3b" />

---
Thanks to [Big Blue Door](https://www.bigbluedoor.net/) for sponsoring my time to work on this.