### PR TITLE
Prefer file description field for document link text if set and available

### DIFF
--- a/localgov_base.theme
+++ b/localgov_base.theme
@@ -429,17 +429,17 @@ function localgov_base_preprocess_file_link(&$variables): void {
     $document_title = $variables['link']['#title'];
 
     if ($media) {
-      // Get the current view mode and field display settings.
-      $view_mode = $variables['element']['#view_mode'] ?? 'default';
-      $field_name = $variables['element']['#field_name'] ?? NULL;
+      // Assume some defaults for document media type.
+      $view_mode = 'default';
+      $media_file_field_name = ($media->bundle() === 'document') ? 'field_media_file' : NULL;
 
       // Initialise this variable as false.
       $use_description = FALSE;
 
-      if ($field_name) {
+      if ($media_file_field_name) {
         $entity_display_repository = \Drupal::service('entity_display.repository');
         $entity_display = $entity_display_repository->getViewDisplay($media->getEntityTypeId(), $media->bundle(), $view_mode);
-        $field_display = $entity_display->getComponent($field_name);
+        $field_display = $entity_display->getComponent($media_file_field_name);
 
         if ($field_display && isset($field_display['settings']['use_description_as_link_text'])) {
           $use_description = $field_display['settings']['use_description_as_link_text'];

--- a/localgov_base.theme
+++ b/localgov_base.theme
@@ -6,6 +6,7 @@
  */
 
 use Drupal\Component\Utility\Crypt;
+use Drupal\Core\Entity\EntityDisplayRepository;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Url;
 use Drupal\media\MediaInterface;
@@ -433,11 +434,12 @@ function localgov_base_preprocess_file_link(&$variables): void {
       $view_mode = $variables['element']['#view_mode'] ?? 'default';
       $field_name = $variables['element']['#field_name'] ?? NULL;
 
-      // Initialise this variable as false
+      // Initialise this variable as false.
       $use_description = FALSE;
 
       if ($field_name) {
-        $entity_display = \Drupal\Core\Entity\Entity\EntityViewDisplay::collectRenderDisplay($media, $view_mode);
+        $entity_display_repository = \Drupal::service('entity_display.repository');
+        $entity_display = $entity_display_repository->getViewDisplay($media->getEntityTypeId(), $media->bundle(), $view_mode);
         $field_display = $entity_display->getComponent($field_name);
 
         if ($field_display && isset($field_display['settings']['use_description_as_link_text'])) {

--- a/localgov_base.theme
+++ b/localgov_base.theme
@@ -433,8 +433,9 @@ function localgov_base_preprocess_file_link(&$variables): void {
       $view_mode = 'default';
       $media_file_field_name = ($media->bundle() === 'document') ? 'field_media_file' : NULL;
 
-      // Initialise this variable as false.
+      // Initialise description variables.
       $use_description = FALSE;
+      $description = '';
 
       if ($media_file_field_name) {
         $entity_display_repository = \Drupal::service('entity_display.repository');
@@ -445,7 +446,7 @@ function localgov_base_preprocess_file_link(&$variables): void {
           $use_description = $field_display['settings']['use_description_as_link_text'];
         }
       }
-
+      
       // Get the description from the file field if available.
       if ($use_description && $file->_referringItem) {
         $description = $file->_referringItem->description ?? '';

--- a/localgov_base.theme
+++ b/localgov_base.theme
@@ -428,14 +428,13 @@ function localgov_base_preprocess_file_link(&$variables): void {
   if (isset($variables['link']['#title'])) {
     $document_title = $variables['link']['#title'];
 
-    // Check for use_description_as_link_text setting and description field.
-    $use_description = FALSE;
-    $description = '';
-
     if ($media) {
       // Get the current view mode and field display settings.
       $view_mode = $variables['element']['#view_mode'] ?? 'default';
       $field_name = $variables['element']['#field_name'] ?? NULL;
+
+      // Initialise this variable as false
+      $use_description = FALSE;
 
       if ($field_name) {
         $entity_display = \Drupal\Core\Entity\Entity\EntityViewDisplay::collectRenderDisplay($media, $view_mode);

--- a/localgov_base.theme
+++ b/localgov_base.theme
@@ -446,7 +446,7 @@ function localgov_base_preprocess_file_link(&$variables): void {
           $use_description = $field_display['settings']['use_description_as_link_text'];
         }
       }
-      
+
       // Get the description from the file field if available.
       if ($use_description && $file->_referringItem) {
         $description = $file->_referringItem->description ?? '';

--- a/localgov_base.theme
+++ b/localgov_base.theme
@@ -6,7 +6,6 @@
  */
 
 use Drupal\Component\Utility\Crypt;
-use Drupal\Core\Entity\EntityDisplayRepository;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Url;
 use Drupal\media\MediaInterface;
@@ -452,7 +451,7 @@ function localgov_base_preprocess_file_link(&$variables): void {
         $description = $file->_referringItem->description ?? '';
       }
 
-      // Use description as link text if setting is enabled and description exists.
+      // Use description as link text if enabled and description exists.
       if ($use_description && !empty($description)) {
         $document_title = $description;
       }

--- a/localgov_base.theme
+++ b/localgov_base.theme
@@ -428,11 +428,40 @@ function localgov_base_preprocess_file_link(&$variables): void {
   if (isset($variables['link']['#title'])) {
     $document_title = $variables['link']['#title'];
 
+    // Check for use_description_as_link_text setting and description field.
+    $use_description = FALSE;
+    $description = '';
+
     if ($media) {
-      $media_name = $media->get('name')->getString();
-      // If the media name is set and different to the
-      // $variables['link']['#title'], we will use that instead.
-      $document_title = ($media_name && $media_name !== $document_title) ? $media_name : $document_title;
+      // Get the current view mode and field display settings.
+      $view_mode = $variables['element']['#view_mode'] ?? 'default';
+      $field_name = $variables['element']['#field_name'] ?? NULL;
+
+      if ($field_name) {
+        $entity_display = \Drupal\Core\Entity\Entity\EntityViewDisplay::collectRenderDisplay($media, $view_mode);
+        $field_display = $entity_display->getComponent($field_name);
+
+        if ($field_display && isset($field_display['settings']['use_description_as_link_text'])) {
+          $use_description = $field_display['settings']['use_description_as_link_text'];
+        }
+      }
+
+      // Get the description from the file field if available.
+      if ($use_description && $file->_referringItem) {
+        $description = $file->_referringItem->description ?? '';
+      }
+
+      // Use description as link text if setting is enabled and description exists.
+      if ($use_description && !empty($description)) {
+        $document_title = $description;
+      }
+      else {
+        // Otherwise, see about using the media name.
+        $media_name = $media->get('name')->getString();
+        // If the media name is set and different to the
+        // $variables['link']['#title'], we will use that instead.
+        $document_title = ($media_name && $media_name !== $document_title) ? $media_name : $document_title;
+      }
     }
 
     $variables['link']['#title'] = [

--- a/localgov_base.theme
+++ b/localgov_base.theme
@@ -431,7 +431,7 @@ function localgov_base_preprocess_file_link(&$variables): void {
     if ($media) {
       // Assume some defaults for document media type.
       $view_mode = 'default';
-      $media_file_field_name = ($media->bundle() === 'document') ? 'field_media_file' : NULL;
+      $media_file_field_name = ($media->bundle() === 'document') ? 'field_media_document' : NULL;
 
       // Initialise description variables.
       $use_description = FALSE;


### PR DESCRIPTION
Closes https://github.com/localgovdrupal/localgov_base/issues/871

Continutes work to render the document files for the case where configuration provided in Drupal Core and known to be used on LGD sites prefers the description field to be used for the document link.

Requires code review.

Requires robust functional testing of the display in localgov_base of: 

Document media configured to use name field
Document media configured to use description field
Document media with no name or description field
Drupal file upload fields
Webform file uploads

### Intended logic 

Use description if " use_description_as_link_text " is set in document media manage display and description field has value.

Otherwise 

Use name field with fall backs as before