### PR TITLE
allowing configuring how many top tasks per row

### DIFF
--- a/config/install/localgov_base.settings.yml
+++ b/config/install/localgov_base.settings.yml
@@ -8,3 +8,4 @@ localgov_base_localgov_guides_stacked_heading: FALSE
 localgov_base_localgov_guides_vertical_navigation: TRUE
 localgov_base_mobile_breakpoint_js: '768'
 localgov_base_responsive_wysiwyg_tables: TRUE
+localgov_base_services_top_tasks_per_row: 4

--- a/config/schema/localgov_base.schema.yml
+++ b/config/schema/localgov_base.schema.yml
@@ -41,3 +41,8 @@ localgov_base.settings:
       label: 'Responsive WYSIWYG tables'
       description: 'Choose whether to make WYSIWYG tables responsive or not.'
       default_value: TRUE
+    localgov_base_services_top_tasks_per_row:
+      type: integer
+      label: 'Top tasks per row'
+      description: 'Number of top tasks to display per row in the Services CTA block (1-4).'
+      default_value: 4

--- a/localgov_base.theme
+++ b/localgov_base.theme
@@ -155,9 +155,9 @@ function localgov_base_form_system_theme_settings_alter(&$form, FormStateInterfa
   // Add form element to allow users to choose how many Top Tasks links to show.
   $form['localgov_base_settings']['services_fieldset']['localgov_base_services_top_tasks_per_row'] = [
     '#type'          => 'number',
-    '#title'         => t('Number of Top Tasks per row in Service Landing pages'),
+    '#title'         => t('Number of Top Tasks per row'),
     '#default_value' => theme_get_setting('localgov_base_services_top_tasks_per_row') ? theme_get_setting('localgov_base_services_top_tasks_per_row') : 4,
-    '#description'   => t('The number of Top Tasks links to show in a row for Service Landing pages on desktop (they will automatically be stacked on smaller screens).'),
+    '#description'   => t('The number of Top Tasks links to show in a row for Service pages and Service Landing pages on desktop (they will automatically be stacked on smaller screens).'),
     '#min'           => 1,
     '#max'           => 4,
   ];

--- a/localgov_base.theme
+++ b/localgov_base.theme
@@ -145,6 +145,26 @@ function localgov_base_form_system_theme_settings_alter(&$form, FormStateInterfa
     '#description'   => t('This will display the guide navigation vertically above the guide.'),
   ];
 
+  // Create a fieldset for Services-related settings.
+  $form['localgov_base_settings']['services_fieldset'] = [
+    '#type' => 'fieldset',
+    '#title' => t('Services Display Settings'),
+    '#description' => t('Control how services are displayed on the site.'),
+  ];
+
+  // Add form element to allow users to choose how many Top Tasks links to show.
+  $form['localgov_base_settings']['services_fieldset']['localgov_base_services_top_tasks_per_row'] = [
+    '#type'          => 'number',
+    '#title'         => t('Number of Top Tasks per row in Service Landing pages'),
+    '#default_value' => theme_get_setting('localgov_base_services_top_tasks_per_row') ? theme_get_setting('localgov_base_services_top_tasks_per_row') : 4,
+    '#description'   => t('The number of Top Tasks links to show in a row for Service Landing pages on desktop (they will automatically be stacked on smaller screens).'),
+    '#min'           => 1,
+    '#max'           => 4,
+  ];
+
+  // Add a custom validation handler for our theme settings.
+  $form['#validate'][] = 'localgov_base_theme_settings_validate';
+
   $form['#validate'][] = 'localgov_base_theme_settings_validate';
 }
 
@@ -398,6 +418,41 @@ function localgov_base_preprocess_block(&$variables): void {
     }
   }
 
+}
+
+/**
+ * Implements hook_preprocess_services_cta_block().
+ */
+function localgov_base_preprocess_services_cta_block(&$variables): void {
+  $top_tasks_per_row = theme_get_setting('localgov_base_services_top_tasks_per_row');
+
+  // Allowing is_null will mean current sites that have not set this value
+  // will default to 3 items per row, as per previous behaviour.
+  if (is_null($top_tasks_per_row)) {
+    $top_tasks_per_row = 3;
+  }
+  if ($top_tasks_per_row < 1 || $top_tasks_per_row > 4) {
+    $top_tasks_per_row = 4;
+  }
+
+  switch ($top_tasks_per_row) {
+    case 1:
+      $variables['top_task_row_size'] = 'full';
+      break;
+
+    case 2:
+      $variables['top_task_row_size'] = 'one-half';
+      break;
+
+    case 3:
+      $variables['top_task_row_size'] = 'one-third';
+      break;
+
+    case 4:
+    default:
+      $variables['top_task_row_size'] = 'one-quarter';
+      break;
+  }
 }
 
 /**

--- a/localgov_base.theme
+++ b/localgov_base.theme
@@ -431,9 +431,6 @@ function localgov_base_preprocess_services_cta_block(&$variables): void {
   if (is_null($top_tasks_per_row)) {
     $top_tasks_per_row = 3;
   }
-  if ($top_tasks_per_row < 1 || $top_tasks_per_row > 4) {
-    $top_tasks_per_row = 4;
-  }
 
   switch ($top_tasks_per_row) {
     case 1:
@@ -453,6 +450,7 @@ function localgov_base_preprocess_services_cta_block(&$variables): void {
       $variables['top_task_row_size'] = 'one-quarter';
       break;
   }
+
 }
 
 /**

--- a/localgov_base.theme
+++ b/localgov_base.theme
@@ -426,12 +426,6 @@ function localgov_base_preprocess_block(&$variables): void {
 function localgov_base_preprocess_services_cta_block(&$variables): void {
   $top_tasks_per_row = theme_get_setting('localgov_base_services_top_tasks_per_row');
 
-  // Allowing is_null will mean current sites that have not set this value
-  // will default to 3 items per row, as per previous behaviour.
-  if (is_null($top_tasks_per_row)) {
-    $top_tasks_per_row = 3;
-  }
-
   switch ($top_tasks_per_row) {
     case 1:
       $variables['top_task_row_size'] = 'full';

--- a/templates/block/services-cta-block.html.twig
+++ b/templates/block/services-cta-block.html.twig
@@ -40,7 +40,7 @@
 <nav{{ attributes.addClass(classes).setAttribute('aria-label', 'Section Navigation'|t) }}>
   <ul class="lgd-row service-cta-block__list">
     {% for button in buttons %}
-      <li class="lgd-row__one-third service-cta-block__list-item service-cta-block__list-item--{{ loop.index}}">
+      <li class="lgd-row__{{ top_task_row_size }} service-cta-block__list-item service-cta-block__list-item--{{ loop.index}}">
         <a href="{{ button.url }}" class="service-cta-block__link service-cta-block__link--{{ button.type }}">
           <span class="service-cta-block__link-title">{{ button.title }}</span>
           {% include "@localgov_base/includes/icons/icon.html.twig" with {


### PR DESCRIPTION
Closes #897

## What does this change?

Add a configuration option for how many top tasks we want to show per row for service landing pages, with the default being 4-in-a-row. 

Currently we have 3, so will need to have a note on the release notes that to keep the same feature we currently have, you will need to go to your theme settings and set it to `3` then save the form and export the config.

## How to test

- Go to theme settings page
- Scroll to bottom
- Set how many items per row for top tasks

---
Thanks to [Big Blue Door](https://www.bigbluedoor.net/) for sponsoring my time to work on this.